### PR TITLE
Fix empty predicate error message

### DIFF
--- a/config/errors.yml
+++ b/config/errors.yml
@@ -2,7 +2,7 @@ en:
   errors:
     array?: "must be an array"
 
-    empty?: "cannot be empty"
+    empty?: "must be empty"
 
     exclusion?: "must not be one of: %{list}"
 

--- a/spec/integration/error_compiler_spec.rb
+++ b/spec/integration/error_compiler_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Dry::Validation::ErrorCompiler do
           [:input, [:tags, [:result, [nil, [:val, [:predicate, [:empty?, []]]]]]]]
         )
 
-        expect(msg).to eql(tags: ['cannot be empty'])
+        expect(msg).to eql(tags: ['must be empty'])
       end
     end
 


### PR DESCRIPTION
```ruby
require 'bundler/setup'
require 'dry-validation'

UserSchema = Dry::Validation.Schema do
  key(:sample) { empty? }
end

result = UserSchema.({
  sample: [23]
})

unless result.success?
  puts result.messages
end

# :sample=>["cannot be empty"]}
```

That reads bad: "Sample cannot be empty", but it should be "Sample must be empty".