### PR TITLE
Confusing/ambiguous aspects of DSL syntax

### DIFF
--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -1,9 +1,9 @@
 require 'dry-validation'
 
 schema = Dry::Validation.Schema do
-  key(:email).required
+  required(:email).not_nil
 
-  key(:age).required(:int?, gt?: 18)
+  required(:age).not_nil(:int?, gt?: 18)
 end
 
 errors = schema.call(email: 'jane@doe.org', age: 19).messages

--- a/examples/each.rb
+++ b/examples/each.rb
@@ -2,7 +2,7 @@ require 'byebug'
 require 'dry-validation'
 
 schema = Dry::Validation.Schema do
-  key(:phone_numbers).each(:str?)
+  required(:phone_numbers).each(:str?)
 end
 
 errors = schema.call(phone_numbers: '').messages

--- a/examples/form.rb
+++ b/examples/form.rb
@@ -1,9 +1,9 @@
 require 'dry-validation'
 
 schema = Dry::Validation.Form do
-  key(:email).required
+  required(:email).not_nil
 
-  key(:age).required(:int?, gt?: 18)
+  required(:age).not_nil(:int?, gt?: 18)
 end
 
 errors = schema.call('email' => '', 'age' => '18').messages

--- a/examples/nested.rb
+++ b/examples/nested.rb
@@ -1,14 +1,14 @@
 require 'dry-validation'
 
 schema = Dry::Validation.Schema do
-  key(:address).schema do
-    key(:city).required(min_size?: 3)
+  required(:address).schema do
+    required(:city).not_nil(min_size?: 3)
 
-    key(:street).required
+    required(:street).not_nil
 
-    key(:country).schema do
-      key(:name).required
-      key(:code).required
+    required(:country).schema do
+      required(:name).not_nil
+      required(:code).not_nil
     end
   end
 end

--- a/lib/dry/validation/schema/dsl.rb
+++ b/lib/dry/validation/schema/dsl.rb
@@ -23,9 +23,10 @@ module Dry
         end
         alias_method :to_s, :inspect
 
-        def key(name, &block)
+        def required(name, &block)
           define(name, Key, &block)
         end
+        alias_method :key, :required
 
         def optional(name, &block)
           define(name, Key, :then, &block)

--- a/lib/dry/validation/schema/rule.rb
+++ b/lib/dry/validation/schema/rule.rb
@@ -24,11 +24,12 @@ module Dry
           add_rule(rule)
         end
 
-        def required(*predicates)
+        def not_nil(*predicates)
           rule = ([key(:filled?)] + infer_predicates(predicates)).reduce(:and)
 
           add_rule(__send__(type, rule))
         end
+        alias_method :required, :not_nil
 
         def maybe(*predicates)
           rule =

--- a/spec/integration/attr_spec.rb
+++ b/spec/integration/attr_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Dry::Validation::Schema, 'defining attr-based schema' do
   describe 'with a flat structure' do
     subject(:schema) do
       Dry::Validation.Schema do
-        attr(:email).required
+        attr(:email).not_nil
         attr(:age) { none? | (int? & gt?(18)) }
       end
     end
@@ -22,18 +22,18 @@ RSpec.describe Dry::Validation::Schema, 'defining attr-based schema' do
   describe 'with nested structures' do
     subject(:schema) do
       Dry::Validation.Schema do
-        attr(:email).required
+        attr(:email).not_nil
 
         attr(:age) { none? | (int? & gt?(18)) }
 
         attr(:address) do
           attr(:city) { min_size?(3) }
 
-          attr(:street).required
+          attr(:street).not_nil
 
           attr(:country) do
-            attr(:name).required
-            attr(:code).required
+            attr(:name).not_nil
+            attr(:code).not_nil
           end
         end
 

--- a/spec/integration/custom_error_messages_spec.rb
+++ b/spec/integration/custom_error_messages_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Dry::Validation do
           config.messages_file = SPEC_ROOT.join('fixtures/locales/en.yml')
         end
 
-        key(:email, &:filled?)
+        required(:email, &:filled?)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Dry::Validation do
             config.messages = :i18n
           end
 
-          key(:email, &:filled?)
+          required(:email, &:filled?)
         end
       end
 

--- a/spec/integration/custom_predicates_spec.rb
+++ b/spec/integration/custom_predicates_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Dry::Validation do
           config.predicates = Test::Predicates
         end
 
-        key(:email) { filled? & email? }
+        required(:email) { filled? & email? }
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe Dry::Validation do
           end
         end
 
-        key(:email) { filled? & email? }
+        required(:email) { filled? & email? }
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Dry::Validation do
   describe 'custom predicate which requires an arbitrary dependency' do
     subject(:schema) do
       Dry::Validation.Schema(base_class) do
-        key(:email).required(:email?)
+        required(:email).not_nil(:email?)
 
         configure do
           option :email_check
@@ -97,7 +97,7 @@ RSpec.describe Dry::Validation do
         end
       end
 
-      key(:email).required(:email?)
+      required(:email).not_nil(:email?)
     end
 
     expect { schema.(email: 'foo').messages }.to raise_error(

--- a/spec/integration/hints_spec.rb
+++ b/spec/integration/hints_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Validation hints' do
   context 'with yaml messages' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:age) do |age|
+        required(:age) do |age|
           age.none? | (age.int? & age.gt?(18))
         end
       end
@@ -32,7 +32,7 @@ RSpec.describe 'Validation hints' do
       Dry::Validation.Schema do
         configure { configure { |c| c.messages = :i18n } }
 
-        key(:age) do |age|
+        required(:age) do |age|
           age.none? | (age.int? & age.gt?(18))
         end
       end
@@ -44,8 +44,8 @@ RSpec.describe 'Validation hints' do
   context 'when type expectation is specified' do
     subject(:schema)  do
       Dry::Validation.Schema do
-        key(:email).required
-        key(:name).required(:str?, size?: 5..25)
+        required(:email).not_nil
+        required(:name).not_nil(:str?, size?: 5..25)
       end
     end
 

--- a/spec/integration/injecting_rules_spec.rb
+++ b/spec/integration/injecting_rules_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Schema / Injecting Rules' do
   subject(:schema) do
     Dry::Validation.Schema(rules: other.class.rules) do
-      key(:email).maybe
+      required(:email).maybe
 
       rule(:email) { value(:login).true? > value(:email).filled? }
     end
@@ -9,7 +9,7 @@ RSpec.describe 'Schema / Injecting Rules' do
 
   let(:other) do
     Dry::Validation.Schema do
-      key(:login) { |value| value.bool? }
+      required(:login) { |value| value.bool? }
     end
   end
 

--- a/spec/integration/localized_error_messages_spec.rb
+++ b/spec/integration/localized_error_messages_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dry::Validation, 'with localized messages' do
             config.messages = :i18n
           end
 
-          key(:email) { |email| email.filled? }
+          required(:email) { |email| email.filled? }
         end
       end
 
@@ -38,7 +38,7 @@ RSpec.describe Dry::Validation, 'with localized messages' do
             end
           end
 
-          key(:email) { |email| email.filled? }
+          required(:email) { |email| email.filled? }
         end
       end
 

--- a/spec/integration/optional_keys_spec.rb
+++ b/spec/integration/optional_keys_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Dry::Validation::Schema do
       Dry::Validation.Schema do
         optional(:email) { |email| email.filled? }
 
-        key(:address) do
-          key(:city, &:filled?)
-          key(:street, &:filled?)
+        required(:address) do
+          required(:city, &:filled?)
+          required(:street, &:filled?)
 
           optional(:phone_number) do
             none? | str?

--- a/spec/integration/schema/array_schema_spec.rb
+++ b/spec/integration/schema/array_schema_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Dry::Validation::Schema, 'for an array' do
   subject(:schema) do
     Dry::Validation.Schema do
       each do
-        key(:prefix).required
-        key(:value).required
+        required(:prefix).not_nil
+        required(:value).not_nil
       end
     end
   end

--- a/spec/integration/schema/check_rules_spec.rb
+++ b/spec/integration/schema/check_rules_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Schema, 'using high-level rules' do
           end
         end
 
-        key(:login).required(:bool?)
-        key(:email).maybe
+        required(:login).not_nil(:bool?)
+        required(:email).maybe
 
         rule(:email_presence) { value(:login).true?.then(value(:email).filled?) }
 
@@ -83,18 +83,18 @@ RSpec.describe Schema, 'using high-level rules' do
   describe 'with nested schemas' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:command).required(:str?, inclusion?: %w(First Second))
+        required(:command).not_nil(:str?, inclusion?: %w(First Second))
 
-        key(:args).required(:hash?)
+        required(:args).not_nil(:hash?)
 
         rule(first_args: [:command, :args]) do |command, args|
           command.eql?('First')
-            .then(args.schema { key(:first).required(:bool?) })
+            .then(args.schema { required(:first).not_nil(:bool?) })
         end
 
         rule(second_args: [:command, :args]) do |command, args|
           command.eql?('Second')
-            .then(args.schema { key(:second).required(:bool?) })
+            .then(args.schema { required(:second).not_nil(:bool?) })
         end
       end
     end

--- a/spec/integration/schema/check_with_nth_el_spec.rb
+++ b/spec/integration/schema/check_with_nth_el_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'Check depending on nth element in an array' do
   subject(:schema) do
     Dry::Validation.Schema do
-      key(:tags).each(:str?)
+      required(:tags).each(:str?)
 
       rule(red: [[:tags, 0]]) do |value|
         value.eql?('red')

--- a/spec/integration/schema/each_with_set_spec.rb
+++ b/spec/integration/schema/each_with_set_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'Schema with each and set rules' do
   subject(:schema) do
     Dry::Validation.Schema do
-      key(:payments).each do
-        key(:method).required(:str?)
-        key(:amount).required(:float?)
+      required(:payments).each do
+        required(:method).not_nil(:str?)
+        required(:amount).not_nil(:float?)
       end
     end
   end

--- a/spec/integration/schema/form_spec.rb
+++ b/spec/integration/schema/form_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe Dry::Validation::Schema::Form, 'defining a schema' do
   subject(:schema) do
     Dry::Validation.Form do
-      key(:email).required
+      required(:email).not_nil
 
-      key(:age).maybe(:int?, gt?: 18)
+      required(:age).maybe(:int?, gt?: 18)
 
-      key(:address).schema do
-        key(:city).required
-        key(:street).required
+      required(:address).schema do
+        required(:city).not_nil
+        required(:street).not_nil
 
-        key(:loc).schema do
-          key(:lat).required(:float?)
-          key(:lng).required(:float?)
+        required(:loc).schema do
+          required(:lat).not_nil(:float?)
+          required(:lng).not_nil(:float?)
         end
       end
 
@@ -121,9 +121,9 @@ RSpec.describe Dry::Validation::Schema::Form, 'defining a schema' do
   describe 'with nested schema in a high-level rule' do
     subject(:schema) do
       Dry::Validation.Form do
-        key(:address).maybe(:hash?)
+        required(:address).maybe(:hash?)
 
-        key(:delivery).required(:bool?)
+        required(:delivery).not_nil(:bool?)
 
         rule(address: [:delivery, :address]) do |delivery, address|
           delivery.true?.then(address.schema(AddressSchema))
@@ -133,8 +133,8 @@ RSpec.describe Dry::Validation::Schema::Form, 'defining a schema' do
 
     before do
       AddressSchema = Dry::Validation.Form do
-        key(:city).required
-        key(:zipcode).required(:int?)
+        required(:city).not_nil
+        required(:zipcode).not_nil(:int?)
       end
     end
 

--- a/spec/integration/schema/inheriting_schema_spec.rb
+++ b/spec/integration/schema/inheriting_schema_spec.rb
@@ -1,16 +1,16 @@
 RSpec.describe 'Inheriting schema' do
   subject(:schema) do
     Dry::Validation.Schema(base_schema) do
-      key(:location).schema do
-        key(:lat).required(:float?)
-        key(:lng).required(:float?)
+      required(:location).schema do
+        required(:lat).not_nil(:float?)
+        required(:lng).not_nil(:float?)
       end
     end
   end
 
   let(:base_schema) do
     Dry::Validation.Schema do
-      key(:city).required
+      required(:city).not_nil
     end
   end
 

--- a/spec/integration/schema/input_processor_spec.rb
+++ b/spec/integration/schema/input_processor_spec.rb
@@ -5,18 +5,18 @@ RSpec.describe Dry::Validation::Schema, 'setting input processor in schema' do
         config.input_processor = :sanitizer
       end
 
-      key(:email).required
+      required(:email).not_nil
 
-      key(:age).maybe(:int?, gt?: 18)
+      required(:age).maybe(:int?, gt?: 18)
 
-      key(:address).schema do
-        key(:city).required
-        key(:street).required
+      required(:address).schema do
+        required(:city).not_nil
+        required(:street).not_nil
       end
 
-      key(:phone_numbers).each do
-        key(:prefix).required
-        key(:value).required
+      required(:phone_numbers).each do
+        required(:prefix).not_nil
+        required(:value).not_nil
       end
     end
   end

--- a/spec/integration/schema/macros/confirmation_spec.rb
+++ b/spec/integration/schema/macros/confirmation_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Macros #confirmation' do
           end
         end
 
-        key(:password).maybe(min_size?: 3).confirmation
+        required(:password).maybe(min_size?: 3).confirmation
       end
     end
 

--- a/spec/integration/schema/macros/each_spec.rb
+++ b/spec/integration/schema/macros/each_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe 'Macros #each' do
     context 'with a nested key' do
       subject(:schema) do
         Dry::Validation.Schema do
-          key(:songs).each do
-            key(:title).required
+          required(:songs).each do
+            required(:title).not_nil
           end
         end
       end
@@ -34,10 +34,10 @@ RSpec.describe 'Macros #each' do
     context 'with a nested schema' do
       subject(:schema) do
         Dry::Validation.Schema do
-          key(:songs).each do
+          required(:songs).each do
             schema do
-              key(:title).required
-              key(:author).required
+              required(:title).not_nil
+              required(:author).not_nil
             end
           end
         end
@@ -78,7 +78,7 @@ RSpec.describe 'Macros #each' do
   context 'with inferred predicates and a form schema' do
     subject(:schema) do
       Dry::Validation.Form do
-        key(:songs).each(:str?)
+        required(:songs).each(:str?)
       end
     end
 

--- a/spec/integration/schema/macros/maybe_spec.rb
+++ b/spec/integration/schema/macros/maybe_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Macros #maybe' do
   describe 'with no args' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:email).maybe
+        required(:email).maybe
       end
     end
 
@@ -15,7 +15,7 @@ RSpec.describe 'Macros #maybe' do
   describe 'with a predicate with args' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:name).maybe(min_size?: 3)
+        required(:name).maybe(min_size?: 3)
       end
     end
 

--- a/spec/integration/schema/macros/required_spec.rb
+++ b/spec/integration/schema/macros/required_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Macros #required' do
   describe 'with no args' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:email).required
+        required(:email).not_nil
       end
     end
 
@@ -16,7 +16,7 @@ RSpec.describe 'Macros #required' do
   describe 'with a type specification' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:age).required(:int?)
+        required(:age).not_nil(:int?)
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe 'Macros #required' do
     context 'with a flat arg' do
       subject(:schema) do
         Dry::Validation.Schema do
-          key(:age).required(:int?, gt?: 18)
+          required(:age).not_nil(:int?, gt?: 18)
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.describe 'Macros #required' do
     context 'with a range arg' do
       subject(:schema) do
         Dry::Validation.Schema do
-          key(:age).required(:int?, size?: 18..24)
+          required(:age).not_nil(:int?, size?: 18..24)
         end
       end
 

--- a/spec/integration/schema/macros/when_spec.rb
+++ b/spec/integration/schema/macros/when_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe 'Macros #when' do
   context 'with a result rule returned from the block' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:email).maybe
+        required(:email).maybe
 
-        key(:login).required.when(:true?) do
+        required(:login).not_nil.when(:true?) do
           value(:email).filled?
         end
       end
@@ -22,10 +22,10 @@ RSpec.describe 'Macros #when' do
   describe 'with a result rule depending on another result' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:left).maybe(:int?)
-        key(:right).maybe(:int?)
+        required(:left).maybe(:int?)
+        required(:right).maybe(:int?)
 
-        key(:compare).maybe(:bool?).when(:true?) do
+        required(:compare).maybe(:bool?).when(:true?) do
           value(:left).gt?(value(:right))
         end
       end
@@ -43,10 +43,10 @@ RSpec.describe 'Macros #when' do
   describe 'with multiple result rules' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:email).maybe
-        key(:password).maybe
+        required(:email).maybe
+        required(:password).maybe
 
-        key(:login).maybe(:bool?).when(:true?) do
+        required(:login).maybe(:bool?).when(:true?) do
           value(:email).filled?
           value(:password).filled?
         end

--- a/spec/integration/schema/nested_values_spec.rb
+++ b/spec/integration/schema/nested_values_spec.rb
@@ -1,14 +1,14 @@
 RSpec.describe Schema, 'using nested values' do
   let(:schema) do
     Dry::Validation.Schema do
-      key(:email).maybe
+      required(:email).maybe
 
-      key(:settings) do
-        optional(:offers).required(:bool?).when(:true?) do
+      required(:settings) do
+        optional(:offers).not_nil(:bool?).when(:true?) do
           value([:settings, :newsletter]).false?
         end
 
-        key(:newsletter).required(:bool?).when(:true?) do
+        required(:newsletter).not_nil(:bool?).when(:true?) do
           value(:email).filled?
         end
       end

--- a/spec/integration/schema/not_spec.rb
+++ b/spec/integration/schema/not_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Schema with negated rules' do
         end
       end
 
-      optional(:eat_cake).required
-      optional(:have_cake).required
+      optional(:eat_cake).not_nil
+      optional(:have_cake).not_nil
 
       rule(:be_reasonable) do
         value(:eat_cake).eql?('yes!') & value(:have_cake).eql?('yes!').not

--- a/spec/integration/schema/numbers_spec.rb
+++ b/spec/integration/schema/numbers_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Dry::Validation::Schema do
   subject(:schema) do
     Dry::Validation.Schema do
-      key(:age).required(:number?, :int?)
+      required(:age).not_nil(:number?, :int?)
     end
   end
 

--- a/spec/integration/schema/option_with_default_spec.rb
+++ b/spec/integration/schema/option_with_default_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dry::Validation::Schema, 'defining an option with default value' 
         end
       end
 
-      key(:email) { filled? & unique?(:email) }
+      required(:email) { filled? & unique?(:email) }
     end
   end
 

--- a/spec/integration/schema/reusing_schema_spec.rb
+++ b/spec/integration/schema/reusing_schema_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe 'Reusing schemas' do
   subject(:schema) do
     Dry::Validation.Schema do
-      key(:city).required
+      required(:city).not_nil
 
-      key(:location).schema(LocationSchema)
+      required(:location).schema(LocationSchema)
     end
   end
 
@@ -11,8 +11,8 @@ RSpec.describe 'Reusing schemas' do
     LocationSchema = Dry::Validation.Schema do
       configure { config.input_processor = :form }
 
-      key(:lat).required(:float?)
-      key(:lng).required(:float?)
+      required(:lat).not_nil(:float?)
+      required(:lng).not_nil(:float?)
     end
   end
 

--- a/spec/integration/schema/using_types_spec.rb
+++ b/spec/integration/schema/using_types_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Dry::Validation::Schema, 'defining schema using dry types' do
   subject(:schema) do
     Dry::Validation.Schema do
-      key(:email).required(Email)
-      key(:age).maybe(Age)
-      key(:country).required(Country)
+      required(:email).not_nil(Email)
+      required(:age).maybe(Age)
+      required(:country).not_nil(Country)
       optional(:admin).maybe(AdminBit)
     end
   end
@@ -50,7 +50,7 @@ RSpec.describe Dry::Validation::Schema, 'defining schema using dry types' do
   context "structs" do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:person).required(Person)
+        required(:person).not_nil(Person)
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe Dry::Validation::Schema, 'defining schema using dry types' do
       Dry::Validation.Schema do
         configure { config.input_processor = :sanitizer }
 
-        key(:email).required(Dry::Types['strict.string'].constructor(&:strip))
+        required(:email).not_nil(Dry::Types['strict.string'].constructor(&:strip))
       end
     end
 

--- a/spec/integration/schema/xor_spec.rb
+++ b/spec/integration/schema/xor_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'Schema with xor rules' do
         end
       end
 
-      key(:eat_cake).required
+      required(:eat_cake).not_nil
 
-      key(:have_cake).required
+      required(:have_cake).not_nil
 
       rule(:be_reasonable) do
         value(:eat_cake).eql?('yes!') ^ value(:have_cake).eql?('yes!')

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -2,8 +2,8 @@ RSpec.describe Dry::Validation::Schema, 'defining key-based schema' do
   describe 'with a flat structure' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:email).required
-        key(:age) { none? | (int? & gt?(18)) }
+        required(:email).not_nil
+        required(:age) { none? | (int? & gt?(18)) }
       end
     end
 
@@ -30,22 +30,22 @@ RSpec.describe Dry::Validation::Schema, 'defining key-based schema' do
   describe 'with nested structures' do
     subject(:schema) do
       Dry::Validation.Schema do
-        key(:email).required
+        required(:email).not_nil
 
-        key(:age).maybe(:int?, gt?: 18)
+        required(:age).maybe(:int?, gt?: 18)
 
-        key(:address).schema do
-          key(:city).required(min_size?: 3)
+        required(:address).schema do
+          required(:city).not_nil(min_size?: 3)
 
-          key(:street).required
+          required(:street).not_nil
 
-          key(:country).schema do
-            key(:name).required
-            key(:code).required
+          required(:country).schema do
+            required(:name).not_nil
+            required(:code).not_nil
           end
         end
 
-        key(:phone_numbers).each(:str?)
+        required(:phone_numbers).each(:str?)
       end
     end
 

--- a/spec/unit/schema/key_spec.rb
+++ b/spec/unit/schema/key_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Schema::Key do
 
     it 'returns a key rule & disjunction rule created within the block' do
       user.hash? do
-        key(:email) { none? | filled? }
+        required(:email) { none? | filled? }
       end
 
       expect(user.to_ast).to eql([

--- a/spec/unit/schema/value_spec.rb
+++ b/spec/unit/schema/value_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Schema::Value do
     end
 
     it 'creates a rule for a specified key using a macro' do
-      rule = value.key(:address).required
+      rule = value.key(:address).not_nil
 
       expect(rule.to_ast).to eql(expected_ast)
     end
@@ -51,9 +51,9 @@ RSpec.describe Schema::Value do
 
     it 'creates a rule for specified keys using blocks' do
       rule = value.key(:address) do
-        key(:location) do
-          key(:lat) { filled? }
-          key(:lng) { filled? }
+        required(:location) do
+          required(:lat) { filled? }
+          required(:lng) { filled? }
         end
       end
 
@@ -62,9 +62,9 @@ RSpec.describe Schema::Value do
 
     it 'creates a rule for specified keys using macros' do
       rule = value.key(:address) do
-        key(:location) do
-          key(:lat).required
-          key(:lng).required
+        required(:location) do
+          required(:lat).not_nil
+          required(:lng).not_nil
         end
       end
 
@@ -93,8 +93,8 @@ RSpec.describe Schema::Value do
 
     it 'creates a rule for specified keys using blocks' do
       rule = value.key(:address) do
-        key(:city) { filled? }
-        key(:zipcode) { filled? }
+        required(:city) { filled? }
+        required(:zipcode) { filled? }
       end
 
       expect(rule.to_ast).to eql(expected_ast)
@@ -102,8 +102,8 @@ RSpec.describe Schema::Value do
 
     it 'creates a rule for specified keys using macros' do
       rule = value.key(:address) do
-        key(:city).required
-        key(:zipcode).required
+        required(:city).not_nil
+        required(:zipcode).not_nil
       end
 
       expect(rule.to_ast).to eql(expected_ast)
@@ -126,8 +126,8 @@ RSpec.describe Schema::Value do
 
     it 'creates an each rule with other rules returned from the block' do
       rule = value.each do
-        key(:method) { str? }
-        key(:amount) { float? }
+        required(:method) { str? }
+        required(:amount) { float? }
       end
 
       expect(rule.to_ast).to eql(
@@ -153,7 +153,7 @@ RSpec.describe Schema::Value do
     subject(:user) { Schema::Value.new }
 
     it 'builds hash? & rule created within the block' do
-      rule = user.hash? { key(:email).required }
+      rule = user.hash? { required(:email).not_nil }
 
       expect(rule.to_ast).to eql([
         :and, [
@@ -168,10 +168,10 @@ RSpec.describe Schema::Value do
 
     it 'builds hash? & rule created within the block with deep nesting' do
       rule = user.hash? do
-        key(:address) do
+        required(:address) do
           hash? do
-            key(:city).required
-            key(:zipcode).required
+            required(:city).not_nil
+            required(:zipcode).not_nil
           end
         end
       end


### PR DESCRIPTION
As an admitted heretic who initially spurned dry-validation—but has since taken a second look at it after my own effort began to look like an attempt at re-implementing dry-v—I come bearing a n00b's perspective on the syntax, and a change suggestion.

The current syntax—while clearly documented—is moderately confusing, and induces a rather muddled mental model that can persist even after scrutinizing the docs and examples. This can be put down to a number of things:

1.  The left = key, right = value divide is not readily apparent, and in fact can be the opposite of obvious, e.g. `key(:foo).required` *does* require the key, but as a consequence of using `key` and not `optional`.
2.  The required-ness of `key` is implicit, so it doesn't show up as a contrasting element in relation to `optional` (or counter-balancing `.required`) in examples, to help construct the mental model. The only thing that contrasts is `required`, which relates to values.
3.  It goes without saying, but `key`/`optional` are not symmetrical terms or semantically opposed to one another so it's not as obvious that they're *meant* to have opposite/related effect as it could be
4.  On the value side, `maybe` and `required` aren't symmetrical either (granted, a truly symmetrical relationship would be "can't be nil/must be nil", but that'd be a bit pedantic). Their relation to their effects are meaningful, but w/r/t to each other they differ semantically—you wouldn't for instance ever say "This thing is required, but this thing is maybe."
5.  The sides cross-pollinate. `required` and `optional` are a natural pair, but they're used to mean two different things, weakening simultaneously their semantic power AND the right/left distinction. To a lesser extent, "maybe" can also be ambiguous and could easily be interpreted as meaning there maybe a key (with a value, nil or not), rather than the value may be nil. 

My proposal is simply to make things symmetrical and explicit, so that the distinctions being made are clearer even to a naive observer. It also removes most of the ambiguity in the terms used. Misunderstandings are still possible, but most would be resolved with just the left/right rule being pointed out.

```ruby
schema = Dry::Validation.Schema do
  required(:email).not_nil(format?: EMAIL_REGEX)
  optional(:age).maybe(:int?, gt?: 18)
end
```

1.  `key` is now `required`. `required/optional` are opposites, and it surfaces the previously implicit requirement.
2.  `required` is now `not_nil`. It pays to be explicit, here... not only is there `key(:foo).required` confusion to avoid, but the entire question of whether nil is a value or not (and thus satisfying a requirement to have a value) is intractable and a distraction. Rather than make assumptions, we instead make our intent unambiguous and explicit.
3.  `maybe` remains a truncated form of `maybe_nil`, for brevity. The semantics are still slightly off (`mustn't_be_nil` seemed superfluous), but "may be nil" and "not nil" are close enough and relate well to each other regardless.

*Update*: It's now clear to me that `required` does more than ensure the value isn't nil—further semantics I wasn't aware of. How to address that is covered in the discussion.
