### PR TITLE
Add odd? and even? message defaults

### DIFF
--- a/config/errors.yml
+++ b/config/errors.yml
@@ -14,6 +14,10 @@ en:
 
     number?: "must be a number"
 
+    odd?: "must be odd"
+
+    even?: "must be even"
+
     gt?: "must be greater than %{num}"
 
     gteq?: "must be greater than or equal to %{num}"


### PR DESCRIPTION
`:odd?` and `:even?` predicates are included in dry-logic and should therefore be included in the default messages yaml.