### PR TITLE
Fix bug when validating custom types

### DIFF
--- a/lib/dry/validation/input_processor_compiler.rb
+++ b/lib/dry/validation/input_processor_compiler.rb
@@ -27,6 +27,8 @@ module Dry
       def visit_type(type, *args)
         if type.is_a?(Types::Constructor)
           [:constructor, [type.primitive, type.fn]]
+        elsif type.respond_to?(:rule)
+          visit(type.rule.to_ast, *args)
         else
           DEFAULT_TYPE_NODE.first
         end

--- a/lib/dry/validation/input_processor_compiler.rb
+++ b/lib/dry/validation/input_processor_compiler.rb
@@ -28,7 +28,7 @@ module Dry
         if type.is_a?(Types::Constructor)
           [:constructor, [type.primitive, type.fn]]
         else
-          DEFAULT_TYPE_NODE
+          DEFAULT_TYPE_NODE.first
         end
       end
 

--- a/spec/integration/schema/using_types_spec.rb
+++ b/spec/integration/schema/using_types_spec.rb
@@ -90,4 +90,20 @@ RSpec.describe Dry::Validation::Schema, 'defining schema using dry types' do
       expect(result.to_h).to eql(email: 'jane@doe.org')
     end
   end
+
+  context 'custom types' do
+    subject(:schema) do
+      Dry::Validation.Form do
+        key(:quantity).required(Dry::Types['strict.int'].constrained(gt: 1))
+        key(:percentage).required(Dry::Types['strict.decimal'].constrained(gt: 0, lt: 1))
+      end
+    end
+
+    it 'applies custom types to input prior validation' do
+      result = schema.(quantity: 2, percentage: BigDecimal('0.5'))
+
+      expect(result).to be_success
+      expect(result.to_h).to eql(quantity: 2, percentage: BigDecimal('0.5'))
+    end
+  end
 end

--- a/spec/integration/schema/using_types_spec.rb
+++ b/spec/integration/schema/using_types_spec.rb
@@ -96,14 +96,15 @@ RSpec.describe Dry::Validation::Schema, 'defining schema using dry types' do
       Dry::Validation.Form do
         key(:quantity).required(Dry::Types['strict.int'].constrained(gt: 1))
         key(:percentage).required(Dry::Types['strict.decimal'].constrained(gt: 0, lt: 1))
+        key(:switch).required(Dry::Types['strict.bool'])
       end
     end
 
     it 'applies custom types to input prior validation' do
-      result = schema.(quantity: 2, percentage: BigDecimal('0.5'))
+      result = schema.(quantity: '2', percentage: '0.5', switch: '0')
 
       expect(result).to be_success
-      expect(result.to_h).to eql(quantity: 2, percentage: BigDecimal('0.5'))
+      expect(result.to_h).to eql(quantity: 2, percentage: BigDecimal('0.5'), switch: false)
     end
   end
 end


### PR DESCRIPTION
I was interested in looking at https://github.com/dry-rb/dry-validation/issues/103 - I've managed to get a passing spec (without breaking the build) but I can't help feeling that that this isn't the _actual_ solution. I'd love to seeing another failing spec.