### PR TITLE
Update dry-types deps to support JSON coercions

### DIFF
--- a/dry-validation.gemspec
+++ b/dry-validation.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-container', '~> 0.2', '>= 0.2.8'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-logic', '~> 0.2', '>= 0.2.2'
-  spec.add_runtime_dependency 'dry-types', '~> 0.6', '>= 0.6.0'
+  spec.add_runtime_dependency 'dry-types', '~> 0.7', '>= 0.7.1'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
`dry-types` v0.7.1 introduced `JSON::*` coercions which dry-v relies on.