### PR TITLE
Custom predicate params in error messages

### DIFF
--- a/lib/dry/validation/error_compiler/input.rb
+++ b/lib/dry/validation/error_compiler/input.rb
@@ -132,6 +132,9 @@ module Dry
         meth = :"options_for_#{predicate}"
 
         defaults = { name: rule, rule: rule, value: input }
+        args.each_with_index do |arg, index|
+          defaults["arg#{index}".to_sym] = arg
+        end
 
         if respond_to?(meth)
           defaults.merge!(__send__(meth, args))

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -3,3 +3,5 @@ en:
     rules:
       email:
         filled?: "Please provide your email"
+      text:
+        custom_limit: "Custom limit of %{arg0} exceeded"

--- a/spec/integration/custom_error_messages_spec.rb
+++ b/spec/integration/custom_error_messages_spec.rb
@@ -45,4 +45,26 @@ RSpec.describe Dry::Validation do
       include_context 'schema with customized messages'
     end
   end
+
+  describe 'custom predicate error messages' do
+    subject(:schema) do
+      Dry::Validation.Schema do
+        configure do
+          config.messages_file = SPEC_ROOT.join('fixtures/locales/en.yml')
+
+          def custom_limit(limit, input)
+            input.length <= limit
+          end
+        end
+
+        required(:text) { custom_limit(5) }
+      end
+    end
+
+    it 'returns compiled error messages with custom predicate args available as keys' do
+      expect(schema.(text: 'This is just dummy text').messages).to eql(
+        text: ['Custom limit of 5 exceeded']
+      )
+    end
+  end
 end


### PR DESCRIPTION
Currently there is no way to access all parameters of a custom predicate in the error message.
This pr just makes every parameter of a custom predicate method available (value is already available).

For now this means all args are accessible by `arg0`, `arg1` and so on.

Relates to #114 