### PR TITLE
Make rule work without block params

### DIFF
--- a/spec/integration/schema/check_rules_spec.rb
+++ b/spec/integration/schema/check_rules_spec.rb
@@ -34,6 +34,41 @@ RSpec.describe Schema, 'using high-level rules' do
     end
   end
 
+  context 'composing rules without block parameters' do
+    subject(:schema) do
+      Dry::Validation.Schema do
+        configure do
+          def self.messages
+            Messages.default.merge(
+              en: { errors: { destiny: 'you must select either red or blue' } }
+            )
+          end
+        end
+
+        optional(:red).maybe
+        optional(:blue).maybe
+
+        rule(destiny: [:red, :blue]) do
+          red.filled? | blue.filled?
+        end
+      end
+    end
+
+    it 'passes when only red is filled' do
+      expect(schema.(red: '1')).to be_success
+    end
+
+    it 'fails when keys are missing' do
+      expect(schema.({})).to be_failure
+    end
+
+    it 'fails when red and blue are not filled ' do
+      expect(schema.(red: nil, blue: nil).messages[:destiny]).to eql(
+        ['you must select either red or blue']
+      )
+    end
+  end
+
   context 'composing specific predicates' do
     let(:schema) do
       Dry::Validation.Schema do


### PR DESCRIPTION
This is a stab at fixing #92. I guess it could be seen as an ugly hack though, adding methods to the value instance. 

I moved as much of the code as I could out of the conditionals. Clearer to me, but maybe I should have kept separate instance_exec invocations depending on if there are any args?

The spec part is copy and paste from the spec for the old syntax. Please let me know if I should do that through shared examples instead, or in a totally different way/place.
