### PR TITLE
Use included_in? and excluded_from?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'dry-logic', require: false, github: 'dry-rb/dry-logic'
+
 group :test do
   gem 'i18n'
   gem 'codeclimate-test-reporter', platform: :rbx

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -6,6 +6,8 @@ en:
 
     exclusion?: "must not be one of: %{list}"
 
+    excluded_from?: "must not be one of: %{list}"
+
     eql?: "must be equal to %{eql_value}"
 
     not_eql?: "must not be equal to %{eql_value}"
@@ -27,6 +29,8 @@ en:
     hash?: "must be a hash"
 
     inclusion?: "must be one of: %{list}"
+
+    included_in?: "must be one of: %{list}"
 
     bool?: "must be boolean"
 

--- a/lib/dry/validation/error_compiler/input.rb
+++ b/lib/dry/validation/error_compiler/input.rb
@@ -82,7 +82,15 @@ module Dry
         { list: args[0][0].join(', ') }
       end
 
+      def options_for_excluded_from?(*args)
+        { list: args[0][0].join(', ') }
+      end
+
       def options_for_inclusion?(*args)
+        { list: args[0][0].join(', ') }
+      end
+
+      def options_for_included_in?(*args)
         { list: args[0][0].join(', ') }
       end
 

--- a/spec/integration/error_compiler_spec.rb
+++ b/spec/integration/error_compiler_spec.rb
@@ -145,11 +145,35 @@ RSpec.describe Dry::Validation::ErrorCompiler do
       end
     end
 
+    describe ':excluded_from?' do
+      it 'returns valid message' do
+        msg = error_compiler.visit(
+          [:input, [:num, [
+            :result, [2, [:val, [:predicate, [:excluded_from?, [[1, 2, 3]]]]]]]
+          ]]
+        )
+
+        expect(msg).to eql(num: ['must not be one of: 1, 2, 3'])
+      end
+    end
+
     describe ':inclusion?' do
       it 'returns valid message' do
         msg = error_compiler.visit(
           [:input, [:num, [
             :result, [2, [:val, [:predicate, [:inclusion?, [[1, 2, 3]]]]]]]
+          ]]
+        )
+
+        expect(msg).to eql(num: ['must be one of: 1, 2, 3'])
+      end
+    end
+
+    describe ':included_in?' do
+      it 'returns valid message' do
+        msg = error_compiler.visit(
+          [:input, [:num, [
+            :result, [2, [:val, [:predicate, [:included_in?, [[1, 2, 3]]]]]]]
           ]]
         )
 

--- a/spec/integration/schema/check_rules_spec.rb
+++ b/spec/integration/schema/check_rules_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Schema, 'using high-level rules' do
   describe 'with nested schemas' do
     subject(:schema) do
       Dry::Validation.Schema do
-        required(:command).filled(:str?, inclusion?: %w(First Second))
+        required(:command).filled(:str?, included_in?: %w(First Second))
 
         required(:args).filled(:hash?)
 


### PR DESCRIPTION
Use `included_in?` instead of `inclusion?` and `excluded_from?` instead of `exclusion?`.
These predicates are deprecated by `dry-logic` See https://github.com/dry-rb/dry-logic/pull/9.