### PR TITLE
fix form array specs

### DIFF
--- a/spec/integration/form/predicates/array_spec.rb
+++ b/spec/integration/form/predicates/array_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe 'Predicates: Array' do
     context 'with blank input' do
       let(:input) { { 'foo' => '' } }
 
-      it 'is not successful' do
-        expect(result).to be_failing ['must be an array']
+      it 'is successful' do
+        expect(result).to be_successful
       end
     end
 
@@ -154,8 +154,8 @@ RSpec.describe 'Predicates: Array' do
       context 'with blank input' do
         let(:input) { { 'foo' => '' } }
 
-        it 'is not successful' do
-          expect(result).to be_failing ['must be an array']
+        it 'is successful' do
+          expect(result).to be_successful
         end
       end
 
@@ -202,8 +202,8 @@ RSpec.describe 'Predicates: Array' do
       context 'with blank input' do
         let(:input) { { 'foo' => '' } }
 
-        it 'is not successful' do
-          expect(result).to be_failing ['must be an array']
+        it 'is successful' do
+          expect(result).to be_successful
         end
       end
 


### PR DESCRIPTION
following dry-types PR 88, ‘’ coerces to [] which is an array.