### PR TITLE
`each` not applying `array?` before hand when used with an `input_processor`

### DIFF
--- a/spec/integration/schema/predicates/array_spec.rb
+++ b/spec/integration/schema/predicates/array_spec.rb
@@ -190,6 +190,58 @@ RSpec.describe 'Predicates: Array' do
           expect(result).to be_failing 0 => ['must be an integer']
         end
       end
+
+      context "when using an input_processor" do
+        subject(:schema) do
+          Dry::Validation.Schema do
+            configure do
+              config.input_processor = :sanitizer
+            end
+
+            required(:foo).each(:int?)
+          end
+        end
+
+        context 'with missing input' do
+          let(:input) { {} }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['is missing']
+          end
+        end
+
+        context 'with nil input' do
+          let(:input) { { foo: nil } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must be an array']
+          end
+        end
+
+        context 'with blank input' do
+          let(:input) { { foo: '' } }
+
+          it 'is not successful' do
+            expect(result).to be_failing ['must be an array']
+          end
+        end
+
+        context 'with valid input' do
+          let(:input) { { foo: [3] } }
+
+          it 'is successful' do
+            expect(result).to be_successful
+          end
+        end
+
+        context 'with invalid input' do
+          let(:input) { { foo: [:bar] } }
+
+          it 'is not successful' do
+            expect(result).to be_failing 0 => ['must be an integer']
+          end
+        end
+      end
     end
 
     context 'with optional' do


### PR DESCRIPTION
Added some failing spec for the case when `each` is used in a Schema with an `input_processor`.

Related to #170 