### PR TITLE
Fix bug when using predicates with options in each and when

### DIFF
--- a/spec/integration/schema/macros/when_spec.rb
+++ b/spec/integration/schema/macros/when_spec.rb
@@ -62,4 +62,24 @@ RSpec.describe 'Macros #when' do
       )
     end
   end
+
+  context "predicate with options" do
+    subject(:schema) do
+      Dry::Validation.Schema do
+        required(:bar).maybe
+
+        required(:foo).filled.when(size?: 3) do
+          value(:bar).filled?
+        end
+      end
+    end
+
+    it 'generates check rule' do
+      expect(schema.(foo: [1,2,3], bar: nil).messages).to eql(
+        bar: ['must be filled']
+      )
+
+      expect(schema.(foo: [1,2], bar: nil).messages).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This enables you to use predicates that require options (e.g. size, min_size etc.) with the each and when macros.
Specs have been enhanced to cover both cases and a fix applied to correctly handle the conversion of predicate hash to array.

Fixes #171