### PR TITLE
Separate type specs / coercions from predicates

### DIFF
--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -33,7 +33,7 @@ module Dry
         config.rules = config.rules + (options.fetch(:rules, []) + dsl.rules)
         config.checks = config.checks + dsl.checks
         config.path = dsl.path
-        config.type_map = klass.build_type_map(dsl.type_map) if klass.config.type_specs
+        config.type_map = klass.build_type_map(dsl.type_map) if config.type_specs
       end
 
       if options[:build] == false

--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -33,6 +33,10 @@ module Dry
         config.rules = config.rules + (options.fetch(:rules, []) + dsl.rules)
         config.checks = config.checks + dsl.checks
         config.path = dsl.path
+
+        if dsl.type_map.size > 0
+          config.type_map = type_map(dsl.type_map, config.input_processor)
+        end
       end
 
       if options[:build] == false
@@ -48,6 +52,14 @@ module Dry
 
     def self.JSON(options = {}, &block)
       Validation.Schema(Schema::JSON, options, &block)
+    end
+
+    def self.type_map(type_map, input_processor)
+      type_map.each_with_object({}) do |(name, spec), result|
+        result[name] = Array(spec)
+          .map { |id| Types["#{input_processor}.#{id}"] }
+          .reduce(:|)
+      end
     end
   end
 end

--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -7,8 +7,6 @@ require 'dry/validation/schema/form'
 require 'dry/validation/schema/json'
 
 module Dry
-  Types.register('form.string', Dry::Types['string'])
-
   module Validation
     MissingMessageError = Class.new(StandardError)
     InvalidSchemaError = Class.new(StandardError)

--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -57,7 +57,7 @@ module Dry
     def self.type_map(type_map, input_processor)
       type_map.each_with_object({}) do |(name, spec), result|
         result[name] = Array(spec)
-          .map { |id| Types["#{input_processor}.#{id}"] }
+          .map { |id| id.is_a?(Symbol) ? Types["#{input_processor}.#{id}"] : id }
           .reduce(:|)
       end
     end

--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -34,7 +34,7 @@ module Dry
         config.checks = config.checks + dsl.checks
         config.path = dsl.path
 
-        if dsl.type_map.size > 0
+        if config.type_specs
           config.type_map = type_map(dsl.type_map, config.input_processor)
         end
       end
@@ -56,9 +56,15 @@ module Dry
 
     def self.type_map(type_map, input_processor)
       type_map.each_with_object({}) do |(name, spec), result|
-        result[name] = Array(spec)
-          .map { |id| id.is_a?(Symbol) ? Types["#{input_processor}.#{id}"] : id }
-          .reduce(:|)
+        result[name] =
+          case spec
+          when Hash
+            Types["#{input_processor}.hash"].symbolized(spec)
+          else
+            Array(spec)
+              .map { |id| id.is_a?(Symbol) ? Types["#{input_processor}.#{id}"] : id }
+              .reduce(:|)
+          end
       end
     end
   end

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -128,7 +128,7 @@ module Dry
           end
 
         klass.config.path = target.path if other
-        klass.config.input_processor = :noop unless klass.config.type_specs
+        klass.config.input_processor = :noop
 
         klass
       end

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -72,8 +72,11 @@ module Dry
               lookup_type("hash", category).public_send(hash_type, spec)
             when Array
               if spec.size == 1 && spec[0].is_a?(Hash)
-                member = lookup_type("hash", category).public_send(hash_type, (build_type_map(spec[0], category)))
-                lookup_type("array", category).member(member)
+                member_schema = build_type_map(spec[0], category)
+                member_type = lookup_type("hash", category)
+                  .public_send(hash_type, member_schema)
+
+                lookup_type("array", category).member(member_type)
               else
                 spec
                   .map { |id| id.is_a?(Symbol) ? lookup_type(id, category) : id }

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -30,6 +30,7 @@ module Dry
       setting :rules, []
       setting :checks, []
       setting :options, {}
+      setting :type_map, {}
 
       setting :input_processor, :noop
 
@@ -91,6 +92,10 @@ module Dry
         [:schema, self]
       end
 
+      def self.type_map
+        config.type_map
+      end
+
       def self.rules
         config.rules
       end
@@ -133,7 +138,9 @@ module Dry
       def self.input_processor
         @input_processor ||=
           begin
-            if input_processor_compiler
+            if type_map.size > 0
+              Types["#{config.input_processor}.hash"].weak(type_map)
+            elsif input_processor_compiler
               input_processor_compiler.(rule_ast)
             else
               NOOP_INPUT_PROCESSOR
@@ -181,7 +188,10 @@ module Dry
 
       attr_reader :options
 
+      attr_reader :type_map
+
       def initialize(rules, options)
+        @type_map = self.class.type_map
         @predicates = options.fetch(:predicate_registry).bind(self)
         @rule_compiler = SchemaCompiler.new(predicates)
         @error_compiler = options.fetch(:error_compiler)

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -12,7 +12,7 @@ require 'dry/validation/messages'
 require 'dry/validation/error_compiler'
 require 'dry/validation/hint_compiler'
 
-require 'dry/validation/input_processor_compiler'
+require 'dry/validation/schema/deprecated'
 
 module Dry
   module Validation
@@ -33,7 +33,6 @@ module Dry
       setting :type_map, {}
 
       setting :input_processor, :noop
-
       setting :input_processor_map, {
         sanitizer: InputProcessorCompiler::Sanitizer.new,
         json: InputProcessorCompiler::JSON.new,
@@ -56,6 +55,37 @@ module Dry
 
       def self.set_registry!
         config.registry = PredicateRegistry[self, config.predicates]
+      end
+
+      def self.registry
+        config.registry
+      end
+
+      def self.build_type_map(type_specs, category = config.input_processor)
+        type_specs.each_with_object({}) do |(name, spec), result|
+          result[name] =
+            case spec
+            when Hash
+              Types["#{category}.hash"].symbolized(spec)
+            when Array
+              if spec.size == 1 && spec[0].is_a?(Hash)
+                member = Types["#{category}.hash"].symbolized(build_type_map(spec[0], category))
+                Types["#{category}.array"].member(member)
+              else
+                spec
+                  .map { |id| id.is_a?(Symbol) ? Types["#{category}.#{id}"] : id }
+                  .reduce(:|)
+              end
+            when Symbol
+              Types["#{category}.#{spec}"]
+            else
+              spec
+            end
+        end
+      end
+
+      def self.type_map
+        config.type_map
       end
 
       def self.predicates(predicate_set = nil)
@@ -100,10 +130,6 @@ module Dry
         [:schema, self]
       end
 
-      def self.type_map
-        config.type_map
-      end
-
       def self.rules
         config.rules
       end
@@ -143,33 +169,8 @@ module Dry
         @hint_compiler ||= HintCompiler.new(messages, rules: rule_ast)
       end
 
-      def self.input_processor
-        @input_processor ||=
-          begin
-            if type_map.size > 0
-              Types["#{config.input_processor}.hash"].symbolized(type_map)
-            elsif input_processor_compiler
-              input_processor_compiler.(rule_ast)
-            else
-              NOOP_INPUT_PROCESSOR
-            end
-          end
-      end
-
-      def self.input_processor_ast(type)
-        config.input_processor_map.fetch(type).schema_ast(rule_ast)
-      end
-
-      def self.input_processor_compiler
-        @input_processor_comp ||= config.input_processor_map[config.input_processor]
-      end
-
       def self.rule_ast
         @rule_ast ||= config.rules.flat_map(&:rules).map(&:to_ast)
-      end
-
-      def self.registry
-        config.registry
       end
 
       def self.default_options

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -40,10 +40,18 @@ module Dry
         form: InputProcessorCompiler::Form.new,
       }.freeze
 
+      setting :type_specs, false
+
       def self.inherited(klass)
         super
         klass.config.options = klass.config.options.dup
         klass.set_registry!
+      end
+
+      def self.clone
+        klass = Class.new(self)
+        klass.config.rules = []
+        klass
       end
 
       def self.set_registry!
@@ -78,7 +86,7 @@ module Dry
           end
 
         klass.config.path = target.path if other
-        klass.config.input_processor = :noop
+        klass.config.input_processor = :noop unless klass.config.type_specs
 
         klass
       end

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -139,7 +139,7 @@ module Dry
         @input_processor ||=
           begin
             if type_map.size > 0
-              Types["#{config.input_processor}.hash"].weak(type_map)
+              Types["#{config.input_processor}.hash"].symbolized(type_map)
             elsif input_processor_compiler
               input_processor_compiler.(rule_ast)
             else

--- a/lib/dry/validation/schema/deprecated.rb
+++ b/lib/dry/validation/schema/deprecated.rb
@@ -6,8 +6,9 @@ module Dry
       def self.input_processor
         @input_processor ||=
           begin
-            if type_map.size > 0
-              Types["#{config.input_processor}.hash"].symbolized(type_map)
+            if type_map.size > 0 && config.input_processor != :noop
+              lookup_type("hash", config.input_processor)
+                .public_send(config.hash_type, type_map)
             elsif input_processor_compiler
               input_processor_compiler.(rule_ast)
             else

--- a/lib/dry/validation/schema/deprecated.rb
+++ b/lib/dry/validation/schema/deprecated.rb
@@ -1,0 +1,28 @@
+require 'dry/validation/input_processor_compiler'
+
+module Dry
+  module Validation
+    class Schema
+      def self.input_processor
+        @input_processor ||=
+          begin
+            if type_map.size > 0
+              Types["#{config.input_processor}.hash"].symbolized(type_map)
+            elsif input_processor_compiler
+              input_processor_compiler.(rule_ast)
+            else
+              NOOP_INPUT_PROCESSOR
+            end
+          end
+      end
+
+      def self.input_processor_ast(type)
+        config.input_processor_map.fetch(type).schema_ast(rule_ast)
+      end
+
+      def self.input_processor_compiler
+        @input_processor_comp ||= config.input_processor_map[config.input_processor]
+      end
+    end
+  end
+end

--- a/lib/dry/validation/schema/dsl.rb
+++ b/lib/dry/validation/schema/dsl.rb
@@ -24,8 +24,14 @@ module Dry
         end
         alias_method :to_s, :inspect
 
-        def optional(name, &block)
-          define(name, Key, :then, &block)
+        def optional(name, type_spec = nil, &block)
+          rule = define(name, Key, :then, &block)
+
+          if type_spec
+            type_map[name] = type_spec
+          end
+
+          rule
         end
 
         def not

--- a/lib/dry/validation/schema/dsl.rb
+++ b/lib/dry/validation/schema/dsl.rb
@@ -72,8 +72,8 @@ module Dry
           type = key_class.type
 
           val = Value[
-            name, registry: registry, type: type, parent: self,
-            rules: rules, checks: checks
+            name, registry: registry, type: type, parent: self, rules: rules,
+            checks: checks, schema_class: schema_class.clone
           ].__send__(:"#{type}?", name)
 
           if block

--- a/lib/dry/validation/schema/form.rb
+++ b/lib/dry/validation/schema/form.rb
@@ -5,6 +5,7 @@ module Dry
     class Schema::Form < Schema
       configure do |config|
         config.input_processor = :form
+        config.hash_type = :symbolized
       end
     end
   end

--- a/lib/dry/validation/schema/json.rb
+++ b/lib/dry/validation/schema/json.rb
@@ -5,6 +5,7 @@ module Dry
     class Schema::JSON < Schema
       configure do |config|
         config.input_processor = :json
+        config.hash_type = :symbolized
       end
     end
   end

--- a/lib/dry/validation/schema/rule.rb
+++ b/lib/dry/validation/schema/rule.rb
@@ -39,6 +39,14 @@ module Dry
           target.schema?
         end
 
+        def type_map
+          target.type_map
+        end
+
+        def type_map?
+          target.type_map?
+        end
+
         def required(*predicates)
           ::Kernel.warn 'required is deprecated - use filled instead.'
 

--- a/lib/dry/validation/schema/rule.rb
+++ b/lib/dry/validation/schema/rule.rb
@@ -26,6 +26,11 @@ module Dry
 
         def schema(other = nil, &block)
           schema = Schema.create_class(target, other, &block)
+
+          if schema.config.type_specs
+            target.type_map[name] = schema.type_map
+          end
+
           rule = __send__(type, key(:hash?).and(key(schema)))
           add_rule(rule)
         end

--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -42,7 +42,12 @@ module Dry
             if predicates.size > 0
               create_rule([:each, infer_predicates(predicates, new).to_ast])
             else
-              val = Value[name, registry: registry].instance_eval(&block)
+              val = Value[
+                name, registry: registry, schema_class: schema_class.clone
+              ].instance_eval(&block)
+
+              type_map[name] = [val.type_map] if val.schema? && val.type_map?
+
               create_rule([:each, val.to_ast])
             end
 

--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -10,7 +10,8 @@ module Dry
           super
           @type = options.fetch(:type, :key)
           @schema_class = options.fetch(:schema_class, ::Class.new(Schema))
-          @type_map = {}
+          @options = options.merge(type: @type, schema_class: @schema_class)
+          @type_map = parent ? parent.type_map : {}
         end
 
         def key(name, &block)
@@ -101,6 +102,10 @@ module Dry
 
         def root?
           name.nil?
+        end
+
+        def type_map?
+          ! type_map.empty?
         end
 
         def schema?

--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -11,7 +11,7 @@ module Dry
           @type = options.fetch(:type, :key)
           @schema_class = options.fetch(:schema_class, ::Class.new(Schema))
           @options = options.merge(type: @type, schema_class: @schema_class)
-          @type_map = parent ? parent.type_map : {}
+          @type_map = parent && parent.root? ? parent.type_map : {}
         end
 
         def key(name, &block)
@@ -32,6 +32,7 @@ module Dry
 
         def schema(other = nil, &block)
           @schema = Schema.create_class(self, other, &block)
+          type_map.update(@schema.type_map)
           hash?.and(@schema)
         end
 

--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -19,8 +19,12 @@ module Dry
           required(name, &block)
         end
 
-        def required(name, &block)
-          define(name, Key, &block)
+        def required(name, type_spec = nil, &block)
+          rule = define(name, Key, &block)
+          if type_spec
+            type_map[name] = type_spec
+          end
+          rule
         end
 
         def schema(other = nil, &block)

--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -21,9 +21,11 @@ module Dry
 
         def required(name, type_spec = nil, &block)
           rule = define(name, Key, &block)
+
           if type_spec
             type_map[name] = type_spec
           end
+
           rule
         end
 

--- a/spec/integration/schema/form/explicit_types_spec.rb
+++ b/spec/integration/schema/form/explicit_types_spec.rb
@@ -138,6 +138,18 @@ RSpec.describe Dry::Validation::Schema::Form, 'explicit types' do
       end
     end
 
+    it 'fails to coerce gracefuly' do
+      result = schema.(song: nil)
+
+      expect(result.messages).to eql(song: ['must be a hash'])
+      expect(result.to_h).to eql(song: nil)
+
+      result = schema.(song: { tags: nil })
+
+      expect(result.messages).to eql(song: { tags: ['must be an array'] })
+      expect(result.to_h).to eql(song: { tags: nil })
+    end
+
     it 'uses form coercion for nested input' do
       input = {
         'song' => {

--- a/spec/integration/schema/form/explicit_types_spec.rb
+++ b/spec/integration/schema/form/explicit_types_spec.rb
@@ -120,4 +120,38 @@ RSpec.describe Dry::Validation::Schema::Form, 'explicit types' do
       )
     end
   end
+
+  context 'nested schema with arrays' do
+    subject(:schema) do
+      Dry::Validation.Form do
+        configure { config.type_specs = true }
+
+        required(:song).schema do
+          required(:title, :string)
+
+          required(:tags).each do
+            schema do
+              required(:name, :string)
+            end
+          end
+        end
+      end
+    end
+
+    it 'uses form coercion for nested input' do
+      input = {
+        'song' => {
+          'title' => 'dry-rb is awesome lala',
+          'tags' => [{ 'name' => 'red' }, { 'name' => 'blue' }]
+        }
+      }
+
+      expect(schema.(input).to_h).to eql(
+        song: {
+          title: 'dry-rb is awesome lala',
+          tags: [{ name: 'red' }, { name: 'blue' }]
+        }
+      )
+    end
+  end
 end

--- a/spec/integration/schema/form/explicit_types_spec.rb
+++ b/spec/integration/schema/form/explicit_types_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe Dry::Validation::Schema::Form, 'explicit types' do
+  context 'single type spec without rules' do
+    subject(:schema) do
+      Dry::Validation.Form do
+        required(:age, :int)
+      end
+    end
+
+    it 'uses form coercion' do
+      expect(schema.('age' => '19').to_h).to eql(age: 19)
+    end
+  end
+
+  context 'single type spec with rules' do
+    subject(:schema) do
+      Dry::Validation.Form do
+        required(:age, :int).value(:int?, gt?: 18)
+      end
+    end
+
+    it 'applies rules to coerced value' do
+      expect(schema.(age: 19).messages).to be_empty
+      expect(schema.(age: 18).messages).to eql(age: ['must be greater than 18'])
+    end
+  end
+
+  context 'sum type spec without rules' do
+    subject(:schema) do
+      Dry::Validation.Form do
+        required(:age, [:nil, :int])
+      end
+    end
+
+    it 'uses form coercion' do
+      expect(schema.('age' => '19').to_h).to eql(age: 19)
+      expect(schema.('age' => '').to_h).to eql(age: nil)
+    end
+  end
+
+  context 'sum type spec with rules' do
+    subject(:schema) do
+      Dry::Validation.Form do
+        required(:age, [:nil, :int]).maybe(:int?, gt?: 18)
+      end
+    end
+
+    it 'applies rules to coerced value' do
+      expect(schema.(age: nil).messages).to be_empty
+      expect(schema.(age: 19).messages).to be_empty
+      expect(schema.(age: 18).messages).to eql(age: ['must be greater than 18'])
+    end
+  end
+
+  context 'using a type object' do
+    subject(:schema) do
+      Dry::Validation.Form do
+        required(:age, Types::Form::Nil | Types::Form::Int)
+      end
+    end
+
+    it 'uses form coercion' do
+      expect(schema.('age' => '').to_h).to eql(age: nil)
+      expect(schema.('age' => '19').to_h).to eql(age: 19)
+    end
+  end
+end

--- a/spec/integration/schema/json/explicit_types_spec.rb
+++ b/spec/integration/schema/json/explicit_types_spec.rb
@@ -1,0 +1,157 @@
+RSpec.describe Dry::Validation::Schema::JSON, 'explicit types' do
+  context 'single type spec without rules' do
+    subject(:schema) do
+      Dry::Validation.JSON do
+        configure { config.type_specs = true }
+        required(:bdate, :date)
+      end
+    end
+
+    it 'uses json coercion' do
+      expect(schema.('bdate' => '2010-09-08').to_h).to eql(bdate: Date.new(2010, 9, 8))
+    end
+  end
+
+  context 'single type spec with rules' do
+    subject(:schema) do
+      Dry::Validation.JSON do
+        configure { config.type_specs = true }
+        required(:bdate, :date).value(:date?, gt?: Date.new(2009))
+      end
+    end
+
+    it 'applies rules to coerced value' do
+      expect(schema.(bdate: "2010-09-07").messages).to be_empty
+      expect(schema.(bdate: "2008-01-01").messages).to eql(bdate: ['must be greater than 2009-01-01'])
+    end
+  end
+
+  context 'sum type spec without rules' do
+    subject(:schema) do
+      Dry::Validation.JSON do
+        configure { config.type_specs = true }
+        required(:bdate, [:nil, :date])
+      end
+    end
+
+    it 'uses form coercion' do
+      expect(schema.('bdate' => '2010-09-08').to_h).to eql(bdate: Date.new(2010, 9, 8))
+      expect(schema.('bdate' => '').to_h).to eql(bdate: nil)
+    end
+  end
+
+  context 'sum type spec with rules' do
+    subject(:schema) do
+      Dry::Validation.JSON do
+        configure { config.type_specs = true }
+        required(:bdate, [:nil, :date]).maybe(:date?, gt?: Date.new(2008))
+      end
+    end
+
+    it 'applies rules to coerced value' do
+      expect(schema.(bdate: nil).messages).to be_empty
+      expect(schema.(bdate: "2010-09-07").messages).to be_empty
+      expect(schema.(bdate: "2008-01-01").messages).to eql(bdate: ['must be greater than 2008-01-01'])
+    end
+  end
+
+  context 'using a type object' do
+    subject(:schema) do
+      Dry::Validation.JSON do
+        configure { config.type_specs = true }
+        required(:bdate, Types::Json::Nil | Types::Json::Date)
+      end
+    end
+
+    it 'uses form coercion' do
+      expect(schema.('bdate' => '').to_h).to eql(bdate: nil)
+      expect(schema.('bdate' => '2010-09-08').to_h).to eql(bdate: Date.new(2010, 9, 8))
+    end
+  end
+
+  context 'nested schema' do
+    subject(:schema) do
+      Dry::Validation.JSON do
+        configure { config.type_specs = true }
+
+        required(:user).schema do
+          required(:email, :string)
+          required(:bdate, :date)
+
+          required(:address).schema do
+            required(:street, :string)
+            required(:city, :string)
+            required(:zipcode, :string)
+
+            required(:location).schema do
+              required(:lat, :float)
+              required(:lng, :float)
+            end
+          end
+        end
+      end
+    end
+
+    it 'uses form coercion for nested input' do
+      input = {
+        'user' => {
+          'email' => 'jane@doe.org',
+          'bdate' => '2010-09-08',
+          'address' => {
+            'street' => 'Street 1',
+            'city' => 'NYC',
+            'zipcode' => '1234',
+            'location' => { 'lat' => 1.23, 'lng' => 4.56 }
+          }
+        }
+      }
+
+      expect(schema.(input).to_h).to eql(
+        user:  {
+          email: 'jane@doe.org',
+          bdate: Date.new(2010, 9, 8),
+          address: {
+            street: 'Street 1',
+            city: 'NYC',
+            zipcode:  '1234',
+            location: { lat: 1.23, lng: 4.56 }
+          }
+        }
+      )
+    end
+  end
+
+  context 'nested schema with arrays' do
+    subject(:schema) do
+      Dry::Validation.JSON do
+        configure { config.type_specs = true }
+
+        required(:song).schema do
+          required(:title, :string)
+
+          required(:tags).each do
+            schema do
+              required(:name, :string)
+            end
+          end
+        end
+      end
+    end
+
+    it 'uses form coercion for nested input' do
+      input = {
+        'song' => {
+          'title' => 'dry-rb is awesome lala',
+          'tags' => [{ 'name' => 'red' }, { 'name' => 'blue' }]
+        }
+      }
+
+      expect(schema.(input).to_h).to eql(
+        song: {
+          title: 'dry-rb is awesome lala',
+          tags: [{ name: 'red' }, { name: 'blue' }]
+        }
+      )
+    end
+  end
+end

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Dry::Validation::Schema, 'defining key-based schema' do
     describe '#type_map' do
       it 'returns key=>type map' do
         expect(schema.type_map).to eql(
-          email: Types::Form::String, age: Types::Form::Nil | Types::Form::Int
+          email: Types::String, age: Types::Form::Nil | Types::Form::Int
         )
       end
 

--- a/spec/integration/schema_spec.rb
+++ b/spec/integration/schema_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Dry::Validation::Schema, 'defining key-based schema' do
       Dry::Validation.Schema do
         configure do
           config.input_processor = :form
-          config.input_processor_map = {} # enforces usage of type_map
+          config.type_specs = true
         end
 
         required(:email, :string).filled

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,9 +20,6 @@ Dir[SPEC_ROOT.join('support/**/*.rb')].each(&method(:require))
 include Dry::Validation
 
 module Types
-  # FIXME: we should add this to dry-types
-  Dry::Types.register('form.string', Dry::Types['string'])
-
   include Dry::Types.module
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,13 @@ Dir[SPEC_ROOT.join('support/**/*.rb')].each(&method(:require))
 
 include Dry::Validation
 
+module Types
+  # FIXME: we should add this to dry-types
+  Dry::Types.register('form.string', Dry::Types['string'])
+
+  include Dry::Types.module
+end
+
 RSpec.configure do |config|
   config.disable_monkey_patching!
 


### PR DESCRIPTION
This extends existing `required` and `optional` interfaces to support explicit type specs that are used for input coercion which is applied prior validation. This is a pretty big change as we're separating coercion from validation in the DSL too.

Here's how it works:

``` ruby
Dry::Validation.Form do
   # enable explicit type-specs
   configure { config.type_specs = true }

   required(:name, :string)
   required(:age, [:nil, :int])

   # `schema` implies :hash type spec
   required(:address).schema do
     required(:street, :string)
     required(:city, :string)
     required(:zipcode, :string)
   end

   # `each` implies `:array` type spec
   required(:phone_numbers).each do
     schema do
       required(:prefix, :string)
       required(:num, :string)
     end
   end
end
```

Notice that this is **a pure sanitization/coercion schema** without any rules.

Scope of this PR:

- [x] Extend `required` to accept type specs
- [x] Extend `optional` to accept type specs
- [x] Add support for type specs in nested schemas
- [x] Add support for either symbol-based type specs or dry-types objects
- [x] Make sure input-processor is applied only once (which will also fix jruby on CI)
- [x] Clean-up :)

As a second step, which will be done in another PR, I'll add a way to infer rules *from* type specs, which is exactly the opposite of what our complex input-processor compilers are doing. I also suspect some further polishing of the interface directly in master prior 0.8.0 release.

A really cool side-effect of this improvement is: defining a schema is ~80-100 x times faster no, no kidding:

```
Schema defined in 0.075425
Form defined in 5.43349
Form (with type specs) defined in 0.077061
------------------------------------------------------------------------------
Warming up --------------------------------------
              Schema     1.000  i/100ms
                Form     1.000  i/100ms
Form with type specs     1.000  i/100ms
Calculating -------------------------------------
              Schema     15.248  (±13.1%) i/s -     75.000  in   5.045985s
                Form      0.174  (± 0.0%) i/s -      1.000  in   5.749034s
Form with type specs     14.810  (±20.3%) i/s -     71.000  in   5.000067s

Comparison:
              Schema:       15.2 i/s
Form with type specs:       14.8 i/s - same-ish: difference falls within error
                Form:        0.2 i/s - 87.66x slower
```

closes #181 