### PR TITLE
Extend hint functionality and fix issues

### DIFF
--- a/lib/dry/validation/error_compiler.rb
+++ b/lib/dry/validation/error_compiler.rb
@@ -10,7 +10,7 @@ module Dry
       def initialize(messages, options = {})
         @messages = messages
         @options = Hash[options]
-        @hints = @options.fetch(:hints, {})
+        @hints = @options.fetch(:hints, DEFAULT_RESULT)
         @full = options.fetch(:full, false)
       end
 

--- a/lib/dry/validation/hint_compiler.rb
+++ b/lib/dry/validation/hint_compiler.rb
@@ -23,12 +23,14 @@ module Dry
 
       EXCLUDED = [:none?, :filled?, :key?].freeze
 
+      DEFAULT_OPTIONS = { name: nil, input: nil, message_type: :hint }.freeze
+
       def self.cache
         @cache ||= Concurrent::Map.new
       end
 
       def initialize(messages, options = {})
-        super(messages, { name: nil, input: nil }.merge(options))
+        super(messages, DEFAULT_OPTIONS.merge(options))
         @rules = @options.delete(:rules)
         @excluded = @options.fetch(:excluded, EXCLUDED)
         @val_type = options[:val_type]

--- a/lib/dry/validation/hint_compiler.rb
+++ b/lib/dry/validation/hint_compiler.rb
@@ -25,6 +25,8 @@ module Dry
 
       DEFAULT_OPTIONS = { name: nil, input: nil, message_type: :hint }.freeze
 
+      EMPTY_MESSAGES = {}.freeze
+
       def self.cache
         @cache ||= Concurrent::Map.new
       end
@@ -55,7 +57,7 @@ module Dry
         val_type = TYPES[predicate]
 
         return with(val_type: val_type) if val_type
-        return {} if excluded.include?(predicate)
+        return EMPTY_MESSAGES if excluded.include?(predicate)
 
         super
       end

--- a/lib/dry/validation/messages/abstract.rb
+++ b/lib/dry/validation/messages/abstract.rb
@@ -17,6 +17,7 @@ module Dry
         setting :lookup_paths, %w(
           %{root}.rules.%{rule}.%{predicate}.arg.%{arg_type}
           %{root}.rules.%{rule}.%{predicate}
+          %{root}.%{predicate}.%{message_type}
           %{root}.%{predicate}.value.%{rule}.arg.%{arg_type}
           %{root}.%{predicate}.value.%{rule}
           %{root}.%{predicate}.value.%{val_type}.arg.%{arg_type}
@@ -69,7 +70,8 @@ module Dry
             root: root,
             predicate: predicate,
             arg_type: config.arg_types[options[:arg_type]],
-            val_type: config.val_types[options[:val_type]]
+            val_type: config.val_types[options[:val_type]],
+            message_type: options[:message_type] || :failure
           )
 
           tokens[:rule] = predicate unless tokens.key?(:rule)

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -45,7 +45,8 @@ module Dry
             hints = hint_compiler.with(options).call
             comp = error_compiler.with(options.merge(hints: hints))
 
-            comp.(error_ast)
+            messages = comp.(error_ast)
+            comp.dump_messages(messages)
           end
       end
 

--- a/lib/dry/validation/schema.rb
+++ b/lib/dry/validation/schema.rb
@@ -194,7 +194,7 @@ module Dry
       end
 
       def self.rule_ast
-        @rule_ast ||= config.rules.flat_map(&:rules).map(&:to_ast)
+        @rule_ast ||= config.rules.map(&:to_ast)
       end
 
       def self.default_options

--- a/spec/integration/form/predicates/size/range_spec.rb
+++ b/spec/integration/form/predicates/size/range_spec.rb
@@ -134,8 +134,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with blank input' do
             let(:input) { { 'foo' => '' } }
 
-            #see: https://github.com/dry-rb/dry-validation/issues/121
-            xit 'is not successful' do
+            it 'is not successful' do
               expect(result).to be_failing ['length must be within 2 - 3']
             end
           end

--- a/spec/integration/hints_spec.rb
+++ b/spec/integration/hints_spec.rb
@@ -68,4 +68,43 @@ RSpec.describe 'Validation hints' do
       expect(result.messages).to eql(age: ['must be less than 23'])
     end
   end
+
+  context 'when the message uses input value' do
+    subject(:schema) do
+      Dry::Validation.Schema do
+        configure do
+          def self.messages
+            Messages.default.merge(
+              en: {
+                errors: {
+                  blue?: {
+                    failure: '%{value} is not equal to blue',
+                    hint: 'must be equal to blue'
+                  }
+                }
+              }
+            )
+          end
+
+          def blue?(value)
+            value == 'blue'
+          end
+        end
+
+        required(:pill).filled(:blue?)
+      end
+    end
+
+    it 'provides a correct failure message' do
+      expect(schema.(pill: 'red').messages).to eql(
+        pill: ['red is not equal to blue']
+      )
+    end
+
+    it 'provides a correct hint' do
+      expect(schema.(pill: nil).messages).to eql(
+        pill: ['must be filled', 'must be equal to blue']
+      )
+    end
+  end
 end

--- a/spec/integration/schema/predicates/size/range_spec.rb
+++ b/spec/integration/schema/predicates/size/range_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { foo: '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['length must be within 2 - 3', 'size must be within 2 - 3']
+              expect(result).to be_failing ['length must be within 2 - 3']
             end
           end
 
@@ -232,7 +232,7 @@ RSpec.describe 'Predicates: Size' do
             let(:input) { { foo: '' } }
 
             it 'is not successful' do
-              expect(result).to be_failing ['length must be within 2 - 3', 'size must be within 2 - 3']
+              expect(result).to be_failing ['length must be within 2 - 3']
             end
           end
 

--- a/spec/integration/schema/using_types_spec.rb
+++ b/spec/integration/schema/using_types_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Dry::Validation::Schema, 'defining schema using dry types' do
   end
 
   it 'fails when sum-type rule did not pass' do
-    expect(schema.(email: 'jane@doe', age: 19, country: 'Australia', admin: 'foo').messages).to eql(
+    result = schema.(email: 'jane@doe', age: 19, country: 'Australia', admin: 'foo')
+    expect(result.messages).to eql(
       admin: ['must be FalseClass', 'must be TrueClass']
     )
   end


### PR DESCRIPTION
  * Add support for `predicate.failure` and `predicate.hint` lookup path
  * Select failure messages over hints even when their text is different
  * Fix a horrible bug where Schema.rule_ast would duplicate rules 4
    times resulting in hints being generated 4 times (lol!)

closes #184