### PR TITLE
Avoid HintCompiler allocations w/ empty options

### DIFF
--- a/lib/dry/validation/hint_compiler.rb
+++ b/lib/dry/validation/hint_compiler.rb
@@ -40,6 +40,7 @@ module Dry
       end
 
       def with(new_options)
+        return self if new_options.empty?
         super(new_options.merge(rules: rules))
       end
 


### PR DESCRIPTION
This commit improves performance for at least this benchmark:

```ruby
require 'benchmark/ips'
require 'dry-validation'

schema = Dry::Validation.Schema do
  required(:address).schema do
    required(:city).filled(min_size?: 3)

    required(:street).filled

    required(:country).schema do
      required(:name).filled
      required(:code).filled
    end
  end
end

INPUT = { address: { city: 'NYC' } }.freeze

errors = schema.call({}).messages

puts errors.inspect

Benchmark.ips do |x|
  x.report do
    schema.call(INPUT).messages
  end
end
```

## Before

```
Warming up --------------------------------------
                       224.000  i/100ms
Calculating -------------------------------------
                          2.252k (± 1.2%) i/s -     11.424k in   5.072491s
```

## After

```
Warming up --------------------------------------
                       257.000  i/100ms
Calculating -------------------------------------
                          2.573k (± 2.8%) i/s -     13.107k in   5.098857s
```

Do we need specs for this change? :fearful: 

Kind regards,
  Peter