### PR TITLE
Reduce method calls by caching as ivar lazily

### DIFF
--- a/lib/dry/validation/messages/abstract.rb
+++ b/lib/dry/validation/messages/abstract.rb
@@ -98,7 +98,7 @@ module Dry
         end
 
         def cache
-          self.class.cache[self]
+          @cache ||= self.class.cache[self]
         end
       end
     end


### PR DESCRIPTION
dbf9534 made benchmarks fast but tests slow so it has been
reverted in 944558f

This commit make benchmarks _and_ tests fast(er) again by
lazily caching the cache in a ivar.

/cc @solnic 