### PR TITLE
Fix bug with messages hash not matching nested sibling schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.9.4 2016-08-11
+
+### Fixed
+
+* Error messages for sibling deeply nested schemas are nested correctly (timriley)
+
+[Compare v0.9.3...v0.9.4](https://github.com/dryrb/dry-validation/compare/v0.9.3...v0.9.4)
+
 # v0.9.3 2016-07-22
 
 ### Added

--- a/lib/dry/validation/error_compiler.rb
+++ b/lib/dry/validation/error_compiler.rb
@@ -57,8 +57,7 @@ module Dry
         path, other = node
 
         if opts[:path]
-          opts[:path] << path.last
-          visit(other, opts)
+          visit(other, opts.merge(path: opts[:path] + [path.last]))
         else
           visit(other, opts.merge(path: [path], schema: true))
         end

--- a/spec/integration/schema/nested_schemas_spec.rb
+++ b/spec/integration/schema/nested_schemas_spec.rb
@@ -1,4 +1,40 @@
 RSpec.describe Schema, 'nested schemas' do
+  context 'with multiple nested schemas' do
+    subject(:schema) do
+      Dry::Validation.Schema do
+        required(:content).schema do
+          required(:meta).schema do
+            required(:version).filled
+          end
+
+          required(:data).schema do
+            required(:city).filled
+          end
+        end
+      end
+    end
+
+    it 'passes when input is valid' do
+      input = {content: {meta: {version: "1.0"}, data: {city: "Canberra"}}}
+      expect(schema.(input)).to be_success
+    end
+
+    it 'fails when one sub-key is missing' do
+      input = {content: {data: {city: "Canberra"}}}
+      expect(schema.(input).messages).to eql(content: {meta: ['is missing']})
+    end
+
+    it 'fails when both sub-keys are missing' do
+      input = {content: {}}
+      expect(schema.(input).messages).to eql(content: {meta: ['is missing'], data: ['is missing']})
+    end
+
+    it 'fails when the deeply nested keys are invalid' do
+      input = {content: {meta: {version: ""}, data: {city: ""}}}
+      expect(schema.(input).messages).to eql(content: {meta: {version: ["must be filled"]}, data: {city: ["must be filled"]}})
+    end
+  end
+
   context 'with a 2-level deep schema' do
     subject(:schema) do
       Dry::Validation.Schema do


### PR DESCRIPTION
The issue was with the error compiler mutating an array in `visit_schema` that continued to be passed around when further processing other parts of the errors, which resulted in error messages being incorrectly nested.

This resolves #221 (and perhaps some other issues too, since we a few different strangely structured error message hashes as a consequence of this bug).