### PR TITLE
Use I18n.locale or I18n.default_locale when the config specify :18n for the messages

### DIFF
--- a/lib/dry/validation/message_compiler.rb
+++ b/lib/dry/validation/message_compiler.rb
@@ -11,7 +11,7 @@ module Dry
         @messages = messages
         @options = options
         @full = @options.fetch(:full, false)
-        @locale = @options.fetch(:locale, :en)
+        @locale = @options.fetch(:locale, messages.default_locale)
         @default_lookup_options = { message_type: message_type, locale: locale }
       end
 

--- a/lib/dry/validation/messages/abstract.rb
+++ b/lib/dry/validation/messages/abstract.rb
@@ -100,6 +100,10 @@ module Dry
         def cache
           @cache ||= self.class.cache[self]
         end
+
+        def default_locale
+          :en
+        end
       end
     end
   end

--- a/lib/dry/validation/messages/i18n.rb
+++ b/lib/dry/validation/messages/i18n.rb
@@ -18,7 +18,8 @@ module Dry
       end
 
       def key?(key, options)
-        ::I18n.exists?(key, options.fetch(:locale, default_locale))
+        ::I18n.exists?(key, options.fetch(:locale, default_locale)) ||
+        ::I18n.exists?(key, I18n.default_locale)
       end
 
       def merge(path)

--- a/lib/dry/validation/messages/i18n.rb
+++ b/lib/dry/validation/messages/i18n.rb
@@ -18,12 +18,16 @@ module Dry
       end
 
       def key?(key, options)
-        ::I18n.exists?(key, options.fetch(:locale, I18n.default_locale))
+        ::I18n.exists?(key, options.fetch(:locale, default_locale))
       end
 
       def merge(path)
         ::I18n.load_path << path
         self
+      end
+
+      def default_locale
+        I18n.locale || I18n.default_locale || super
       end
     end
   end

--- a/lib/dry/validation/messages/yaml.rb
+++ b/lib/dry/validation/messages/yaml.rb
@@ -34,11 +34,11 @@ module Dry
       end
 
       def get(key, options = {})
-        data[key % { locale: options.fetch(:locale, :en) }]
+        data[key % { locale: options.fetch(:locale, default_locale) }]
       end
 
       def key?(key, options = {})
-        data.key?(key % { locale: options.fetch(:locale, :en) })
+        data.key?(key % { locale: options.fetch(:locale, default_locale) })
       end
 
       def merge(overrides)

--- a/spec/fixtures/locales/pl.yml
+++ b/spec/fixtures/locales/pl.yml
@@ -5,6 +5,10 @@ pl:
       arg:
         default: "wielkość musi być równa %{size}"
         range: "wielkość musi być między %{size_left} a %{size_right}"
+      value:
+        string:
+          arg:
+            default: "wielkość musi być równa %{size}"
     rules:
       email:
         filled?: "Proszę podać adres email"

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -72,6 +72,20 @@ RSpec.describe Messages::I18n do
         expect(message).to eql("size must be within %{size_left} - %{size_right}")
       end
     end
+
+    context 'fallbacking to I18n.default_locale with fallback backend config' do
+      before do
+        require "i18n/backend/fallbacks"
+        I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+      end
+
+      it 'returns a message for a predicate in the default_locale' do
+        message = messages[:even?, rule: :some_number]
+
+        expect(I18n.locale).to eql(:pl)
+        expect(message).to eql("must be even")
+      end
+    end
   end
 
   after(:all) do

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Messages::I18n do
     I18n.config.available_locales_set << :pl
     I18n.load_path.concat(%w(en pl).map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") })
     I18n.backend.load_translations
+    I18n.locale = :pl
   end
 
   describe '#[]' do
@@ -18,58 +19,62 @@ RSpec.describe Messages::I18n do
       it 'returns a message for a predicate' do
         message = messages[:filled?, rule: :name]
 
-        expect(message).to eql("must be filled")
+        expect(message).to eql("nie może być pusty")
       end
 
       it 'returns a message for a specific rule' do
         message = messages[:filled?, rule: :email]
 
-        expect(message).to eql("Please provide your email")
+        expect(message).to eql("Proszę podać adres email")
       end
 
       it 'returns a message for a specific val type' do
         message = messages[:size?, rule: :pages, val_type: String]
 
-        expect(message).to eql("length must be %{size}")
+        expect(message).to eql("wielkość musi być równa %{size}")
       end
 
       it 'returns a message for a specific rule and its default arg type' do
         message = messages[:size?, rule: :pages]
 
-        expect(message).to eql("size must be %{size}")
+        expect(message).to eql("wielkość musi być równa %{size}")
       end
 
       it 'returns a message for a specific rule and its arg type' do
         message = messages[:size?, rule: :pages, arg_type: Range]
 
-        expect(message).to eql("size must be within %{size_left} - %{size_right}")
+        expect(message).to eql("wielkość musi być między %{size_left} a %{size_right}")
       end
     end
 
     context 'with a different locale' do
       it 'returns a message for a predicate' do
-        message = messages[:filled?, rule: :name, locale: :pl]
+        message = messages[:filled?, rule: :name, locale: :en]
 
-        expect(message).to eql("nie może być pusty")
+        expect(message).to eql("must be filled")
       end
 
       it 'returns a message for a specific rule' do
-        message = messages[:filled?, rule: :email, locale: :pl]
+        message = messages[:filled?, rule: :email, locale: :en]
 
-        expect(message).to eql("Proszę podać adres email")
+        expect(message).to eql("Please provide your email")
       end
 
       it 'returns a message for a specific rule and its default arg type' do
-        message = messages[:size?, rule: :pages, locale: :pl]
+        message = messages[:size?, rule: :pages, locale: :en]
 
-        expect(message).to eql("wielkość musi być równa %{size}")
+        expect(message).to eql("size must be %{size}")
       end
 
       it 'returns a message for a specific rule and its arg type' do
-        message = messages[:size?, rule: :pages, arg_type: Range, locale: :pl]
+        message = messages[:size?, rule: :pages, arg_type: Range, locale: :en]
 
-        expect(message).to eql("wielkość musi być między %{size_left} a %{size_right}")
+        expect(message).to eql("size must be within %{size_left} - %{size_right}")
       end
     end
+  end
+
+  after(:all) do
+    I18n.locale = I18n.default_locale
   end
 end

--- a/spec/unit/error_compiler_spec.rb
+++ b/spec/unit/error_compiler_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ErrorCompiler, '#call' do
-  subject(:error_compiler) { ErrorCompiler.new({}) }
+  subject(:error_compiler) { ErrorCompiler.new( Messages.default ) }
 
   it 'returns an empty hash when there are no errors' do
     expect(error_compiler.([])).to be_empty


### PR DESCRIPTION
Based on the conversation in the Issue **#216** the situation was that the default_locale was fixed on `:en` and thus also when you were setting the `config.messages = :i18n` you were obliged to pass the `locale` as a parameter to the messages.

@solnic let me know if this is what you was expecting or you had a different idea?

Thanks! 👍 
