### PR TITLE
Add custom messages

### DIFF
--- a/lib/dry/validation/messages/abstract.rb
+++ b/lib/dry/validation/messages/abstract.rb
@@ -79,7 +79,7 @@ module Dry
           opts = options.reject { |k, _| config.lookup_options.include?(k) }
 
           path = lookup_paths(tokens).detect do |key|
-            key?(key, opts) && get(key, opts).is_a?(String)
+            key?(key, opts) && valid_message?(get(key, opts))
           end
 
           [path, opts]
@@ -103,6 +103,12 @@ module Dry
 
         def default_locale
           :en
+        end
+
+        protected
+
+        def valid_message?(message)
+          message.is_a?(String)
         end
       end
     end

--- a/lib/dry/validation/schema/class_interface.rb
+++ b/lib/dry/validation/schema/class_interface.rb
@@ -13,6 +13,7 @@ module Dry
       setting :predicates, Logic::Predicates
       setting :registry
       setting :messages, :yaml
+      setting :custom_messages, nil
       setting :messages_file
       setting :namespace
       setting :rules, []
@@ -144,8 +145,11 @@ module Dry
 
       def self.default_messages
         case config.messages
-        when :yaml then Messages.default
-        when :i18n then Messages::I18n.new
+        when :yaml   then Messages.default
+        when :i18n   then Messages::I18n.new
+        when :custom then
+          raise "+custom+ messages identifier requires to provide also +custom_messages+" if config.custom_messages.nil?
+          config.custom_messages
         else
           raise "+#{config.messages}+ is not a valid messages identifier"
         end

--- a/spec/integration/custom_error_messages_spec.rb
+++ b/spec/integration/custom_error_messages_spec.rb
@@ -45,4 +45,96 @@ RSpec.describe Dry::Validation do
       include_context 'schema with customized messages'
     end
   end
+
+  context 'custom messages' do
+    context 'with invalid settings' do
+      it 'should return error when config.custom_messages is nil' do
+        expect do
+          Dry::Validation.Schema do
+            configure do
+              config.messages = :custom
+              config.custom_messages = nil
+            end
+
+            required(:email, &:filled?)
+          end
+        end.to raise_error RuntimeError
+      end
+    end
+
+    context 'with valid settings' do
+      subject(:schema) do
+        rspec_context = self
+        Dry::Validation.Schema do
+          configure do
+            config.messages = :custom
+            config.custom_messages = rspec_context.custom_messages
+          end
+
+          required(:email, &:filled?)
+        end
+      end
+
+      let(:custom_messages) do
+        obj = Object.new
+        obj.define_singleton_method(:default_locale) { :en }
+        obj
+      end
+
+      context 'custom messages object returnin string' do
+        before :each do
+          custom_messages.define_singleton_method(:[]) do |*_|
+            'Please provide your email'
+          end
+        end
+
+        include_context 'schema with customized messages'
+      end
+
+      context 'custom messages object returning custom message object' do
+        let(:message) do
+          obj = Object.new
+          obj.define_singleton_method(:%) { |_| self }
+          obj
+        end
+
+        before :each do
+          rspec_context = self
+          custom_messages.define_singleton_method(:[]) do |*_|
+            rspec_context.message
+          end
+        end
+
+        it 'returns compiled error messages' do
+          expect(schema.(email: '').messages).to eql(
+            email: [message]
+          )
+        end
+      end
+
+      context 'custom messages object which is subclass of ' \
+              'Dry::Validation::Messages::Abstract' do
+        let(:message) do
+          obj = Object.new
+          obj.define_singleton_method(:%) { |_| self }
+          obj
+        end
+
+        let(:custom_messages) do
+          rspec_context = self
+          obj = Class.new(Dry::Validation::Messages::Abstract).new
+          obj.define_singleton_method(:get) { |*_| rspec_context.message }
+          obj.define_singleton_method(:key?) { |*_| true }
+          obj.define_singleton_method(:valid_message?) { |*_| true }
+          obj
+        end
+
+        it 'returns compiled error messages' do
+          expect(schema.(email: '').messages).to eql(
+            email: [message]
+          )
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
In my current project validation shouldn't just return messages but objects with fields like :error_code (for example `INVALID_EMAIL_ERROR` and :message (which is an normal message like `Email format is invalid.`).
I didn't know how to do it using :yaml or :i18n messages providers so I created this pull request.

I extended `Dry::Validation::Schema` to accept custom messages object.
The setting option `messages` can now be one of :yaml, :i18n or :custom.
If :custom option is set `custom_messages` should also be set as Object which implements #default_locale and #[](key, options) methods.
Method #[](key, options) should return objects which implement #% (for example Strings but not necessary) or is a subclass of `Dry::Validation::Messages::Abstract` (please check tests for more details how it can be sued).

Plese check is it ok and I hope that it will be merged into master ;)
