### PR TITLE
Fix deprecated warnings in Ruby 2.4.0+

### DIFF
--- a/lib/dry/validation/input_processor_compiler/form.rb
+++ b/lib/dry/validation/input_processor_compiler/form.rb
@@ -21,7 +21,7 @@ module Dry
       CONST_MAP = {
         NilClass => 'form.nil',
         String => 'string',
-        Fixnum => 'form.int',
+        Integer => 'form.int',
         Integer => 'form.int',
         Float => 'form.float',
         BigDecimal => 'form.decimal',

--- a/lib/dry/validation/input_processor_compiler/json.rb
+++ b/lib/dry/validation/input_processor_compiler/json.rb
@@ -17,7 +17,7 @@ module Dry
       CONST_MAP = {
         NilClass => 'nil',
         String => 'string',
-        Fixnum => 'int',
+        Integer => 'int',
         Integer => 'int',
         Float => 'float',
         BigDecimal => 'json.decimal',

--- a/lib/dry/validation/input_processor_compiler/sanitizer.rb
+++ b/lib/dry/validation/input_processor_compiler/sanitizer.rb
@@ -19,7 +19,7 @@ module Dry
       CONST_MAP = {
         NilClass => 'nil',
         String => 'string',
-        Fixnum => 'int',
+        Integer => 'int',
         Integer => 'int',
         Float => 'float',
         BigDecimal => 'decimal',

--- a/lib/dry/validation/predicate_registry.rb
+++ b/lib/dry/validation/predicate_registry.rb
@@ -92,7 +92,7 @@ module Dry
           case args_or_arity
           when Array
             raise_invalid_arity_error(name) if ![0, args_or_arity.size + 1].include?(arity)
-          when Fixnum
+          when Integer
             raise_invalid_arity_error(name) if args_or_arity != arity
           end
         else

--- a/spec/unit/input_processor_compiler/form_spec.rb
+++ b/spec/unit/input_processor_compiler/form_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Dry::Validation::InputProcessorCompiler::Form, '#call' do
         :and,
         [
           [:val, p(:key?, :age)],
-          [:key, [:age, p(:type?, Fixnum)]]
+          [:key, [:age, p(:type?, Integer)]]
         ]
       ]
     ]

--- a/spec/unit/input_processor_compiler/json_spec.rb
+++ b/spec/unit/input_processor_compiler/json_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dry::Validation::InputProcessorCompiler::JSON, '#call' do
         :and,
         [
           [:val, p(:key?, :age)],
-          [:key, [:age, p(:type?, Fixnum)]]
+          [:key, [:age, p(:type?, Integer)]]
         ]
       ]
     ]


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-preview3.

`warning: constant ::Fixnum is deprecated`

Thanks.