### PR TITLE
Removed duplicate 'rspec/core import in rake file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ require 'rspec/core/rake_task'
 
 desc 'Run all specs in spec directory'
 task :run_specs do
-  require 'rspec/core'
 
   RSpec::Core::Runner.run(['spec/integration', 'spec/unit'])
   RSpec.clear_examples


### PR DESCRIPTION
Hello, it seemed that there were two rspec/core imports in the project's Rakefile (per issue #292). I have removed the second one from inside the first task.