### PR TITLE
[WIP] messages(errors: :full) returns an array, not a hash

### DIFF
--- a/lib/dry/validation/message_compiler.rb
+++ b/lib/dry/validation/message_compiler.rb
@@ -19,10 +19,6 @@ module Dry
         @default_lookup_options = { locale: locale }
       end
 
-      def full?
-        @full
-      end
-
       def hints?
         @hints
       end
@@ -160,14 +156,7 @@ module Dry
       end
 
       def message_text(rule, template, tokens, opts)
-        text = template % tokens
-
-        if full?
-          rule_name = messages.rule(rule, opts) || rule
-          "#{rule_name} #{text}"
-        else
-          text
-        end
+        template % tokens
       end
 
       def message_tokens(args)

--- a/lib/dry/validation/message_set.rb
+++ b/lib/dry/validation/message_set.rb
@@ -27,8 +27,12 @@ module Dry
         initialize_placeholders!
       end
 
-      def dump
-        root? ? to_a : to_h
+      def dump(full: false)
+        if full
+          to_h.flat_map { |attr, messages| messages.map { |m| "#{attr} #{m}" } }
+        else
+          root? ? to_a : to_h
+        end
       end
 
       def failures?

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -38,15 +38,15 @@ module Dry
       end
 
       def messages(options = EMPTY_HASH)
-        message_set(options).dump
+        message_set(options).dump(full: options[:full])
       end
 
       def errors(options = EMPTY_HASH)
-        message_set(options.merge(hints: false)).dump
+        message_set(options.merge(hints: false)).dump(full: options[:full])
       end
 
       def hints(options = EMPTY_HASH)
-        message_set(options.merge(failures: false)).dump
+        message_set(options.merge(failures: false)).dump(full: options[:full])
       end
 
       def message_set(options = EMPTY_HASH)

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Dry::Validation::Result do
         either = result.to_either(full: true)
 
         expect(either).to be_left
-        expect(either.value).to eql(name: ['name must be filled', 'name length must be within 2 - 4'])
+        expect(either.value).to eql(['name must be filled', 'name length must be within 2 - 4'])
       end
     end
   end

--- a/spec/integration/message_compiler_spec.rb
+++ b/spec/integration/message_compiler_spec.rb
@@ -58,16 +58,6 @@ RSpec.describe Dry::Validation::MessageCompiler do
   end
 
   describe '#visit with an :input node' do
-    context 'full message' do
-      it 'returns full message including rule name' do
-        msg = message_compiler.with(full: true).visit(
-          [:failure, [:num, [:key, [:num, p(:int?, '2')]]]]
-        )
-
-        expect(msg).to eql('num must be an integer')
-      end
-    end
-
     context 'rule name translations' do
       it 'translates rule name and its message' do
         msg = message_compiler.with(locale: :pl, full: true).visit(

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Dry::Validation::Result do
 
       it 'with full: true returns full messages' do
         expect(result.messages(full: true)).to eql(
-          name: ['name must be filled', 'name length must be within 2 - 4']
+          ['name must be filled', 'name length must be within 2 - 4']
         )
       end
     end
@@ -60,6 +60,10 @@ RSpec.describe Dry::Validation::Result do
       it 'returns failure messages' do
         expect(result.errors).to eql(name: ['must be filled'])
       end
+
+      it 'with full: true returns full messages' do
+        expect(result.errors(full: true)).to eql ['name must be filled']
+      end
     end
 
     describe '#hints' do
@@ -67,6 +71,10 @@ RSpec.describe Dry::Validation::Result do
 
       it 'returns hint messages' do
         expect(result.hints).to eql(name: ['length must be within 2 - 4'])
+      end
+
+      it 'with full: true returns full messages' do
+        expect(result.hints(full: true)).to eql ['name length must be within 2 - 4']
       end
     end
 

--- a/spec/integration/schema/predicates/key_spec.rb
+++ b/spec/integration/schema/predicates/key_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Predicates: Key' do
     end
 
     it 'uses key? predicate for required' do
-      expect(schema.({}).messages(full: true)).to eql(foo: ['foo is missing'])
+      expect(schema.({}).messages(full: true)).to eql(['foo is missing'])
       expect(schema.({}).messages).to eql(foo: ['is missing'])
     end
   end


### PR DESCRIPTION
[Original discussion here](https://discuss.dry-rb.org/t/dry-v-feature-suggestion-returning-an-array-not-a-hash-from-errors/166)

The cleanest way I could get this to work was for MessageCompiler to forget about `full` and just pass it straight into MessageSet#dump. But after writing this, I realised that there's a problem: MessageCompiler, not MessageSet, handles translations, and with my current approach there's no easy way to translate the *key*.

I can't think of a way to fix this that doesn't require major changes to the way MessageCompiler and MessageSet work, e.g. by making MessageSet rather than MessageCompiler handle the translations.

I'm opening the unfinished PR just to get the discussion going again, but I think my suggestion of  keeping the API the same (`messages(full: true)`) might not be feasible. Maybe we could go back to my very first suggestion from the discussion thread: to keep the existing API the same, but to add a second option:

```ruby
result.errors(full: true)
# => {age: ["must be present", "must be at least 18"], name: ["must be 20 characters or less"]}
result.errors(full: true)
# => {age: ["age must be present", "age must be at least 18"], name: ["name must be 20 characters or less"]}
result.errors(full: true, flat: true)
# => ["age must be present", "age must be at least 18", "name must be 20 characters or less"]
```

Although I can't think of a situation where you'd want `flat` to be true but `full` to be false, so maybe this makes more sense:

```ruby
result.errors(full: true)
# => {age: ["must be present", "must be at least 18"], name: ["must be 20 characters or less"]}
result.errors(full: true)
# => {age: ["age must be present", "age must be at least 18"], name: ["name must be 20 characters or less"]}
result.errors(flat: true)
# => ["age must be present", "age must be at least 18", "name must be 20 characters or less"]

# another idea; but I prefer the above one:
result.errors(full: :flat)
# => ["age must be present", "age must be at least 18", "name must be 20 characters or less"]
```

What do you think?