### PR TITLE
Refactor test docstrings

### DIFF
--- a/spec/integration/custom_predicates_spec.rb
+++ b/spec/integration/custom_predicates_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Dry::Validation do
     )
   end
 
-  it 'should work with custom predicate args' do
+  it 'works with custom predicate args' do
     schema = Dry::Validation.Schema do
       configure do
         def self.messages

--- a/spec/integration/form/predicates/empty_spec.rb
+++ b/spec/integration/form/predicates/empty_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe 'Predicates: Empty' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Form do
             required(:foo).filled(:empty?)
           end }.to raise_error InvalidSchemaError
@@ -178,7 +178,7 @@ RSpec.describe 'Predicates: Empty' do
       end
 
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Form do
             required(:foo).maybe(:empty?)
           end }.to raise_error InvalidSchemaError
@@ -244,7 +244,7 @@ RSpec.describe 'Predicates: Empty' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Form do
             optional(:foo).filled(:empty?)
           end }.to raise_error InvalidSchemaError
@@ -252,7 +252,7 @@ RSpec.describe 'Predicates: Empty' do
       end
 
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Form do
             optional(:foo).maybe(:empty?)
           end }.to raise_error InvalidSchemaError

--- a/spec/integration/form/predicates/filled_spec.rb
+++ b/spec/integration/form/predicates/filled_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe 'Predicates: Filled' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Form do
             required(:foo).filled(:filled?)
           end }.to raise_error InvalidSchemaError
@@ -346,7 +346,7 @@ RSpec.describe 'Predicates: Filled' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Form do
             optional(:foo).filled(:filled?)
           end }.to raise_error InvalidSchemaError

--- a/spec/integration/form/predicates/max_size_spec.rb
+++ b/spec/integration/form/predicates/max_size_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Predicates: Max Size' do
     context 'with nil input' do
       let(:input) { { 'foo' => nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe 'Predicates: Max Size' do
     context 'with nil input' do
       let(:input) { { 'foo' => nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -269,7 +269,7 @@ RSpec.describe 'Predicates: Max Size' do
         context 'with nil input' do
           let(:input) { { 'foo' => nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end

--- a/spec/integration/form/predicates/min_size_spec.rb
+++ b/spec/integration/form/predicates/min_size_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Predicates: Min Size' do
     context 'with nil input' do
       let(:input) { { 'foo' => nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe 'Predicates: Min Size' do
     context 'with nil input' do
       let(:input) { { 'foo' => nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe 'Predicates: Min Size' do
         context 'with nil input' do
           let(:input) { { 'foo' => nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -269,7 +269,7 @@ RSpec.describe 'Predicates: Min Size' do
         context 'with nil input' do
           let(:input) { { 'foo' => nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end

--- a/spec/integration/form/predicates/none_spec.rb
+++ b/spec/integration/form/predicates/none_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'Predicates: None' do
 
       #makes no sense see: #134
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Form do
             required(:foo).maybe(:none?)
           end }.to raise_error InvalidSchemaError
@@ -254,7 +254,7 @@ RSpec.describe 'Predicates: None' do
 
       #makes no sense see: #134
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Form do
             optional(:foo).maybe(:none?)
           end }.to raise_error InvalidSchemaError

--- a/spec/integration/form/predicates/size/fixed_spec.rb
+++ b/spec/integration/form/predicates/size/fixed_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { 'foo' => nil } }
 
-        it 'is raises error' do
+        it 'raises error' do
           expect { result }.to raise_error(NoMethodError)
         end
       end
@@ -74,7 +74,7 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { 'foo' => nil } }
 
-        it 'is raises error' do
+        it 'raises error' do
           expect { result }.to raise_error(NoMethodError)
         end
       end
@@ -124,7 +124,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { 'foo' => nil } }
 
-            it 'is raises error' do
+            it 'raises error' do
               expect { result }.to raise_error(NoMethodError)
             end
           end
@@ -270,7 +270,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { 'foo' => nil } }
 
-            it 'is raises error' do
+            it 'raises error' do
               expect { result }.to raise_error(NoMethodError)
             end
           end

--- a/spec/integration/form/predicates/size/range_spec.rb
+++ b/spec/integration/form/predicates/size/range_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { 'foo' => nil } }
 
-        it 'is raises error' do
+        it 'raises error' do
           expect { result }.to raise_error(NoMethodError)
         end
       end
@@ -75,7 +75,7 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { 'foo' => nil } }
 
-        it 'is raises error' do
+        it 'raises error' do
           expect { result }.to raise_error(NoMethodError)
         end
       end
@@ -126,7 +126,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { 'foo' => nil } }
 
-            it 'is raises error' do
+            it 'raises error' do
               expect { result }.to raise_error(NoMethodError)
             end
           end
@@ -272,7 +272,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { 'foo' => nil } }
 
-            it 'is raises error' do
+            it 'raises error' do
               expect { result }.to raise_error(NoMethodError)
             end
           end

--- a/spec/integration/schema/predicates/empty_spec.rb
+++ b/spec/integration/schema/predicates/empty_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe 'Predicates: Empty' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             required(:foo).filled(:empty?)
           end }.to raise_error InvalidSchemaError
@@ -178,7 +178,7 @@ RSpec.describe 'Predicates: Empty' do
       end
 
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             required(:foo).maybe(:empty?)
           end }.to raise_error InvalidSchemaError
@@ -244,7 +244,7 @@ RSpec.describe 'Predicates: Empty' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             optional(:foo).filled(:empty?)
           end }.to raise_error InvalidSchemaError
@@ -252,7 +252,7 @@ RSpec.describe 'Predicates: Empty' do
       end
 
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             optional(:foo).maybe(:empty?)
           end }.to raise_error InvalidSchemaError

--- a/spec/integration/schema/predicates/filled_spec.rb
+++ b/spec/integration/schema/predicates/filled_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe 'Predicates: Filled' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             required(:foo).filled(:filled?)
           end }.to raise_error InvalidSchemaError
@@ -346,7 +346,7 @@ RSpec.describe 'Predicates: Filled' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             optional(:foo).filled(:filled?)
           end }.to raise_error InvalidSchemaError

--- a/spec/integration/schema/predicates/gt_spec.rb
+++ b/spec/integration/schema/predicates/gt_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Predicates: Gt' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe 'Predicates: Gt' do
     context 'with blank input' do
       let(:input) { { foo: '' } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe 'Predicates: Gt' do
     context 'with invalid input type' do
       let(:input) { { foo: [] } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -89,7 +89,7 @@ RSpec.describe 'Predicates: Gt' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe 'Predicates: Gt' do
     context 'with blank input' do
       let(:input) { { foo: '' } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe 'Predicates: Gt' do
     context 'with invalid input type' do
       let(:input) { { foo: [] } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -163,7 +163,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -171,7 +171,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -291,7 +291,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -299,7 +299,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -349,7 +349,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -357,7 +357,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -365,7 +365,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -485,7 +485,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -493,7 +493,7 @@ RSpec.describe 'Predicates: Gt' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end

--- a/spec/integration/schema/predicates/gteq_spec.rb
+++ b/spec/integration/schema/predicates/gteq_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Predicates: Gteq' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe 'Predicates: Gteq' do
     context 'with blank input' do
       let(:input) { { foo: '' } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe 'Predicates: Gteq' do
     context 'with invalid input type' do
       let(:input) { { foo: [] } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -89,7 +89,7 @@ RSpec.describe 'Predicates: Gteq' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe 'Predicates: Gteq' do
     context 'with blank input' do
       let(:input) { { foo: '' } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe 'Predicates: Gteq' do
     context 'with invalid input type' do
       let(:input) { { foo: [] } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -163,7 +163,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -171,7 +171,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -291,7 +291,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -299,7 +299,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -349,7 +349,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -357,7 +357,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -365,7 +365,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -485,7 +485,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -493,7 +493,7 @@ RSpec.describe 'Predicates: Gteq' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end

--- a/spec/integration/schema/predicates/key_spec.rb
+++ b/spec/integration/schema/predicates/key_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Predicates: Key' do
   end
 
   context 'with required' do
-    it "should raise error" do
+    it "raises error" do
       expect { Dry::Validation.Schema do
         required(:foo) { key? }
       end }.to raise_error InvalidSchemaError
@@ -24,7 +24,7 @@ RSpec.describe 'Predicates: Key' do
 
   context 'with optional' do
     subject(:schema) do
-      it "should raise error" do
+      it "raises error" do
         expect { Dry::Validation.Schema do
           optional(:foo) { key? }
         end }.to raise_error InvalidSchemaError
@@ -35,7 +35,7 @@ RSpec.describe 'Predicates: Key' do
   context 'as macro' do
     context 'with required' do
       context 'with value' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             required(:foo).value(:key?)
           end }.to raise_error InvalidSchemaError
@@ -43,7 +43,7 @@ RSpec.describe 'Predicates: Key' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             required(:foo).filled(:key?)
           end }.to raise_error InvalidSchemaError
@@ -51,7 +51,7 @@ RSpec.describe 'Predicates: Key' do
       end
 
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             required(:foo).maybe(:key?)
           end }.to raise_error InvalidSchemaError
@@ -61,7 +61,7 @@ RSpec.describe 'Predicates: Key' do
 
     context 'with optional' do
       context 'with value' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             optional(:foo).value(:key?)
           end }.to raise_error InvalidSchemaError
@@ -69,7 +69,7 @@ RSpec.describe 'Predicates: Key' do
       end
 
       context 'with filled' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             optional(:foo).filled(:key?)
           end }.to raise_error InvalidSchemaError
@@ -77,7 +77,7 @@ RSpec.describe 'Predicates: Key' do
       end
 
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             optional(:foo).maybe(:key?)
           end }.to raise_error InvalidSchemaError

--- a/spec/integration/schema/predicates/lt_spec.rb
+++ b/spec/integration/schema/predicates/lt_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Predicates: Lt' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe 'Predicates: Lt' do
     context 'with blank input' do
       let(:input) { { foo: '' } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe 'Predicates: Lt' do
     context 'with invalid input type' do
       let(:input) { { foo: [] } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe 'Predicates: Lt' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe 'Predicates: Lt' do
     context 'with blank input' do
       let(:input) { { foo: '' } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
       end
     end
@@ -106,7 +106,7 @@ RSpec.describe 'Predicates: Lt' do
     context 'with invalid input type' do
       let(:input) { { foo: [] } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -156,7 +156,7 @@ RSpec.describe 'Predicates: Lt' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -164,7 +164,7 @@ RSpec.describe 'Predicates: Lt' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -172,7 +172,7 @@ RSpec.describe 'Predicates: Lt' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -292,7 +292,7 @@ RSpec.describe 'Predicates: Lt' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -300,7 +300,7 @@ RSpec.describe 'Predicates: Lt' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -486,7 +486,7 @@ RSpec.describe 'Predicates: Lt' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -494,7 +494,7 @@ RSpec.describe 'Predicates: Lt' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end

--- a/spec/integration/schema/predicates/lteq_spec.rb
+++ b/spec/integration/schema/predicates/lteq_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Predicates: Lteq' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -33,7 +33,7 @@ RSpec.describe 'Predicates: Lteq' do
     context 'with blank input' do
       let(:input) { { foo: '' } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe 'Predicates: Lteq' do
     context 'with invalid input type' do
       let(:input) { { foo: [] } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -89,7 +89,7 @@ RSpec.describe 'Predicates: Lteq' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe 'Predicates: Lteq' do
     context 'with blank input' do
       let(:input) { { foo: '' } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe 'Predicates: Lteq' do
     context 'with invalid input type' do
       let(:input) { { foo: [] } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe 'Predicates: Lteq' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -163,7 +163,7 @@ RSpec.describe 'Predicates: Lteq' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -171,7 +171,7 @@ RSpec.describe 'Predicates: Lteq' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -291,7 +291,7 @@ RSpec.describe 'Predicates: Lteq' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -299,7 +299,7 @@ RSpec.describe 'Predicates: Lteq' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -485,7 +485,7 @@ RSpec.describe 'Predicates: Lteq' do
         context 'with blank input' do
           let(:input) { { foo: '' } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(ArgumentError, 'comparison of String with 23 failed')
           end
         end
@@ -493,7 +493,7 @@ RSpec.describe 'Predicates: Lteq' do
         context 'with invalid input type' do
           let(:input) { { foo: [] } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end

--- a/spec/integration/schema/predicates/max_size_spec.rb
+++ b/spec/integration/schema/predicates/max_size_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Predicates: Max Size' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe 'Predicates: Max Size' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -269,7 +269,7 @@ RSpec.describe 'Predicates: Max Size' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end

--- a/spec/integration/schema/predicates/min_size_spec.rb
+++ b/spec/integration/schema/predicates/min_size_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Predicates: Min Size' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe 'Predicates: Min Size' do
     context 'with nil input' do
       let(:input) { { foo: nil } }
 
-      it 'is raises error' do
+      it 'raises error' do
         expect { result }.to raise_error(NoMethodError)
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe 'Predicates: Min Size' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end
@@ -269,7 +269,7 @@ RSpec.describe 'Predicates: Min Size' do
         context 'with nil input' do
           let(:input) { { foo: nil } }
 
-          it 'is raises error' do
+          it 'raises error' do
             expect { result }.to raise_error(NoMethodError)
           end
         end

--- a/spec/integration/schema/predicates/none_spec.rb
+++ b/spec/integration/schema/predicates/none_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe 'Predicates: None' do
 
       #makes no sense see: #134
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             required(:foo).maybe(:none?)
           end }.to raise_error InvalidSchemaError
@@ -254,7 +254,7 @@ RSpec.describe 'Predicates: None' do
 
       #makes no sense see: #134
       context 'with maybe' do
-        it "should raise error" do
+        it "raises error" do
           expect { Dry::Validation.Schema do
             optional(:foo).maybe(:none?)
           end }.to raise_error InvalidSchemaError

--- a/spec/integration/schema/predicates/size/fixed_spec.rb
+++ b/spec/integration/schema/predicates/size/fixed_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { foo: nil } }
 
-        it 'is raises error' do
+        it 'raises error' do
           expect { result }.to raise_error(NoMethodError)
         end
       end
@@ -74,7 +74,7 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { foo: nil } }
 
-        it 'is raises error' do
+        it 'raises error' do
           expect { result }.to raise_error(NoMethodError)
         end
       end
@@ -125,7 +125,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { foo: nil } }
 
-            it 'is raises error' do
+            it 'raises error' do
               expect { result }.to raise_error(NoMethodError)
             end
           end
@@ -273,7 +273,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { foo: nil } }
 
-            it 'is raises error' do
+            it 'raises error' do
               expect { result }.to raise_error(NoMethodError)
             end
           end

--- a/spec/integration/schema/predicates/size/range_spec.rb
+++ b/spec/integration/schema/predicates/size/range_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { foo: nil } }
 
-        it 'is raises error' do
+        it 'raises error' do
           expect { result }.to raise_error(NoMethodError)
         end
       end
@@ -74,7 +74,7 @@ RSpec.describe 'Predicates: Size' do
       context 'with nil input' do
         let(:input) { { foo: nil } }
 
-        it 'is raises error' do
+        it 'raises error' do
           expect { result }.to raise_error(NoMethodError)
         end
       end
@@ -124,7 +124,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { foo: nil } }
 
-            it 'is raises error' do
+            it 'raises error' do
               expect { result }.to raise_error(NoMethodError)
             end
           end
@@ -270,7 +270,7 @@ RSpec.describe 'Predicates: Size' do
           context 'with nil input' do
             let(:input) { { foo: nil } }
 
-            it 'is raises error' do
+            it 'raises error' do
               expect { result }.to raise_error(NoMethodError)
             end
           end

--- a/spec/integration/schema/predicates/type_spec.rb
+++ b/spec/integration/schema/predicates/type_spec.rb
@@ -402,11 +402,11 @@ RSpec.describe 'Predicates: Type' do
       Object.send(:remove_const, :CustomClass)
     end
 
-    it 'it succeeds with valid input' do
+    it 'succeeds with valid input' do
       expect(schema.(foo: CustomClass.new)).to be_success
     end
 
-    it 'it fails with invalid input' do
+    it 'fails with invalid input' do
       expect(schema.(foo: 'oops')).to be_failing ["must be #{CustomClass}"]
     end
   end


### PR DESCRIPTION
I found these while test-driving a `rubocop-rspec` cop that checks for redundant "it"s in test docstrings.

- Removes redundant 'it's at the beginning of test docstrings.
- Converts 'should raise error' and 'is raises error' to just
  'raises error' which is consistent with the other examples in
  the codebase.

I'm happy to make similar changes to other `dry-*` repos if that would be helpful/desired, just lmk!