### PR TITLE
Input types for `hash?` and `array?` fields in JSON schema

### DIFF
--- a/lib/dry/validation/input_processor_compiler/json.rb
+++ b/lib/dry/validation/input_processor_compiler/json.rb
@@ -11,7 +11,9 @@ module Dry
         decimal?: 'json.decimal',
         date?: 'json.date',
         date_time?: 'json.date_time',
-        time?: 'json.time'
+        time?: 'json.time',
+        hash?: 'json.hash',
+        array?: 'json.array'
       }.freeze
 
       CONST_MAP = {

--- a/spec/unit/input_processor_compiler/json_spec.rb
+++ b/spec/unit/input_processor_compiler/json_spec.rb
@@ -248,6 +248,20 @@ RSpec.describe Dry::Validation::InputProcessorCompiler::JSON, '#call' do
     expect(input_type.('ids' => [1, 2, 3])).to eql(ids: [1, 2, 3])
   end
 
+  it 'supports array? without each rule' do
+    rule_ast = [
+      [
+        :and, [
+          [:val, p(:key?, :ids)],
+          [:key, [:ids, p(:array?, [])]]
+        ]
+      ]
+    ]
+
+    input_type = compiler.(rule_ast)
+    expect(input_type.type.member_types[:ids].type.primitive).to eq(Array)
+  end
+
   it 'supports hash? with a set rule' do
     rule_ast = [
       [
@@ -279,5 +293,19 @@ RSpec.describe Dry::Validation::InputProcessorCompiler::JSON, '#call' do
     expect(input_type.('address' => { 'street' => 'ok' })).to eql(
       address: { street: 'ok' }
     )
+  end
+
+  it 'supports hash? without nested rules' do
+    rule_ast = [
+      [
+        :and, [
+          [:val, p(:key?, :address)],
+          [:key, [:address, p(:hash?, [])]]
+        ]
+      ]
+    ]
+
+    input_type = compiler.(rule_ast)
+    expect(input_type.type.member_types[:address].type.primitive).to eq(Hash)
   end
 end


### PR DESCRIPTION
Fixed input types that are generated for `Validator.JSON` schemas
when fields with `hash?` and `array?` are defined without corresponding
nested schema:

```ruby
schema = Dry::Validation.JSON do
  required(:attributes).value(:hash?)
  required(:ids).value(:array?)
end

schema.input_processor
```

was result in:
```
#<Dry::Types::Safe
  type=#<Dry::Types::Hash::Symbolized primitive=Hash
    options={:member_types=>{
      :attributes=>#<Dry::Types::Safe type=#<Dry::Types::Definition primitive=String options={}> options={}>,
      :ids=>#<Dry::Types::Safe type=#<Dry::Types::Definition primitive=String options={}> options={}>}}>
  options={}>
```

Note `primitive=String` on both `:attributes` and `:ids` fields.

Now fixed to be `Hash` and `String` respectively.

=========

I found this issue when investigating huge performance loss with my API classes, and notices what this code executed many times on failure branch, and constantly doing "inspect" on quite large incoming data was slowing down the code.

https://github.com/dry-rb/dry-types/blob/v0.9.4/lib/dry/types/definition.rb#L69

```ruby
def try(input, &block)
  if valid?(input)
    success(input)
  else
    failure = failure(input, "#{input.inspect} must be an instance of #{primitive}")
  block ? yield(failure) : failure
  end
end
```