### PR TITLE
Fix program halt when $DEBUG mode on

### DIFF
--- a/lib/dry/validation/message_compiler.rb
+++ b/lib/dry/validation/message_compiler.rb
@@ -160,7 +160,11 @@ module Dry
       end
 
       def message_text(rule, template, tokens, opts)
-        text = template % tokens
+        text = begin
+          template % tokens
+        rescue ArgumentError
+          template
+        end
 
         if full?
           rule_name = messages.rule(rule, opts) || rule


### PR DESCRIPTION
Fix this issue https://github.com/dry-rb/dry-validation/issues/319

## Test script

```ruby
require 'dry-validation'

$DEBUG = true

schema = Dry::Validation.Schema do
  required(:name).filled
end

result = schema.call(
  email: 'jane@doe.org',
  address: { street: 'Street 1', city: 'NYC', zipcode: '1234' }
)

puts "error message: #{result.messages.inspect}"
```

## Before the fix

```ruby
Exception `ArgumentError' at /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:163 - too many arguments for format string
/Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:163:in `%': too many arguments for format string (ArgumentError)
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:163:in `message_text'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:119:in `visit_predicate'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:40:in `visit'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:45:in `visit_failure'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:40:in `visit'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:78:in `block in visit_and'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:78:in `map'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:78:in `visit_and'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:40:in `visit'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:45:in `visit_failure'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:40:in `visit'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:36:in `block in call'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:36:in `map'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:36:in `call'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/result.rb:53:in `message_set'
	from /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/result.rb:41:in `messages'
	from examples/debug.rb:15:in `<main>'
```

## After the fix

```ruby
Exception `ArgumentError' at /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:164 - too many arguments for format string
Exception `ArgumentError' at /Users/mac/.rvm/gems/ruby-2.3.0/gems/dry-validation-0.10.5/lib/dry/validation/message_compiler.rb:164 - too many arguments for format string
error message: {:name=>["is missing"]}
```
