### PR TITLE
Fix `warning: extra states are no longer copied`

### DIFF
--- a/lib/dry/validation/messages/abstract.rb
+++ b/lib/dry/validation/messages/abstract.rb
@@ -78,7 +78,7 @@ module Dry
 
           tokens[:rule] = predicate unless tokens.key?(:rule)
 
-          opts = options.reject { |k, _| config.lookup_options.include?(k) }
+          opts = options.select { |k, _| !config.lookup_options.include?(k) }
 
           path = lookup_paths(tokens).detect do |key|
             key?(key, opts) && get(key, opts).is_a?(String)


### PR DESCRIPTION
Just a fix for removing the warning when rejecting extra states on a Hash

https://github.com/ruby/ruby/blob/v2_4_1/hash.c#L1335-L1337

Thanks!