### PR TITLE
Fix links in the contribution document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ If you found a bug, report an issue and describe what's the expected behavior ve
 
 ## Reporting feature requests
 
-Report a feature request **only after discussing it first on [discuss.dry-rb.org](https://discuss.dry-rb.org)** where it was accepted. Please provide a concise description of the feature, don't link to a discussion thread, and instead summarize what was discussed.
+Report a feature request **only after discussing it first on [the discussion forum][1]** where it was accepted. Please provide a concise description of the feature, don't link to a discussion thread, and instead summarize what was discussed.
 
 ## Reporting questions, support requests, ideas, concerns etc.
 
-**PLEASE DON'T** - use [discuss.dry-rb.org](http://discuss.dry-rb.org) instead.
+**PLEASE DON'T** - use [the discussion forum][1] instead.
 
 # Pull Request Guidelines
 
@@ -22,8 +22,10 @@ Other requirements:
 2) Follow the style conventions of the surrounding code. In most cases, this is standard ruby style.
 3) Add API documentation if it's a new feature
 4) Update API documentation if it changes an existing feature
-5) Bonus points for sending a PR to [github.com/dry-rb/dry-rb.org](github.com/dry-rb/dry-rb.org) which updates user documentation and guides
+5) Bonus points for sending a PR to [github.com/dry-rb/dry-rb.org](https://github.com/dry-rb/dry-rb.org) which updates user documentation and guides
 
 # Asking for help
 
-If these guidelines aren't helpful, and you're stuck, please post a message on [discuss.dry-rb.org](https://discuss.dry-rb.org).
+If these guidelines aren't helpful, and you're stuck, please post a message on [the discussion forum][1].
+
+[1]: https://discourse.dry-rb.org/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ## Links
 
 * [Documentation](http://dry-rb.org/gems/dry-validation)
+* [Guidelines for contributing](CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
All of the links in CONTRIBUTE.md were broken. This fixes them (and dries the links for easier future fixing :) ) and adds a link from readme to contribution doc.