### PR TITLE
[Issue #353] fix bug with wrong translation key in Messages::I18n#rule

### DIFF
--- a/lib/dry/validation/messages/abstract.rb
+++ b/lib/dry/validation/messages/abstract.rb
@@ -54,8 +54,12 @@ module Dry
           @hash ||= config.hash
         end
 
+        def rule_path(name)
+          "rules.#{name}"
+        end
+
         def rule(name, options = {})
-          path = "%{locale}.rules.#{name}"
+          path = rule_path(name)
           get(path, options) if key?(path, options)
         end
 

--- a/lib/dry/validation/messages/namespaced.rb
+++ b/lib/dry/validation/messages/namespaced.rb
@@ -26,6 +26,15 @@ module Dry
         def default_locale
           messages.default_locale
         end
+
+        def rule_path(name)
+          path_parts = messages.rule_path(name).split('.')
+          [
+              path_parts[0, path_parts.size - 1],
+              namespace,
+              path_parts.last
+          ].join('.')
+        end
       end
     end
   end

--- a/lib/dry/validation/messages/yaml.rb
+++ b/lib/dry/validation/messages/yaml.rb
@@ -49,6 +49,10 @@ module Dry
           self.class.new(data.merge(Messages::YAML.load_file(overrides)))
         end
       end
+
+      def rule_path(name)
+        "%{locale}.#{super(name)}"
+      end
     end
   end
 end

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  rules:
+    user:
+      name: Name
+    email: E-mail
   errors:
     rules:
       email:

--- a/spec/fixtures/locales/pl.yml
+++ b/spec/fixtures/locales/pl.yml
@@ -1,4 +1,8 @@
 pl:
+  rules:
+    user:
+      name: Name
+    email: E-mail
   errors:
     filled?: "nie może być pusty"
     size?:

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -88,6 +88,26 @@ RSpec.describe Messages::I18n do
     end
   end
 
+  describe '#rule' do
+    subject { messages.rule('email') }
+
+    it { expect(subject).to eq('E-mail') }
+  end
+
+  describe '#key?' do
+    subject { messages.key?(key, {locale: :en}) }
+    let(:key) { 'rules.email' }
+
+    it { expect(subject).to be_truthy }
+  end
+
+  describe '#get' do
+    subject { messages.get(key, {locale: :en}) }
+    let(:key) { 'rules.email' }
+
+    it { expect(subject).to eq('E-mail') }
+  end
+
   after(:all) do
     I18n.locale = I18n.default_locale
   end

--- a/spec/integration/messages/namespaced_spec.rb
+++ b/spec/integration/messages/namespaced_spec.rb
@@ -1,0 +1,66 @@
+require 'dry/validation/messages/i18n'
+
+RSpec.describe Messages::Namespaced do
+  let(:namespace) { :user }
+
+  context 'when namespaced build from Messages::YAML' do
+    subject(:messages) { Messages::YAML.new(Messages::YAML.load_file(path)).namespaced(namespace) }
+
+    let(:path) { SPEC_ROOT.join('fixtures/locales/en.yml') }
+
+    describe '#rule' do
+      subject { messages.rule('name') }
+
+      it { expect(subject).to eq('Name') }
+    end
+
+    describe '#key?' do
+      let(:key) { "%{locale}.rules.#{namespace}.name" }
+      subject { messages.key?(key, {locale: :en}) }
+
+      it { expect(subject).to be_truthy }
+    end
+
+    describe '#get' do
+      let(:key) { "%{locale}.rules.#{namespace}.name" }
+      subject { messages.get(key, {locale: :en}) }
+
+      it { expect(subject).to eq('Name') }
+    end
+  end
+
+  context 'when namespaced build from Messages::I18n' do
+    subject(:messages) { Messages::I18n.new.namespaced(namespace) }
+
+    before do
+      I18n.config.available_locales_set << :pl
+      I18n.load_path.concat(%w(en pl).map { |l| SPEC_ROOT.join("fixtures/locales/#{l}.yml") })
+      I18n.backend.load_translations
+      I18n.locale = :pl
+    end
+
+    describe '#rule' do
+      subject { messages.rule('name') }
+
+      it { expect(subject).to eq('Name') }
+    end
+
+    describe '#key?' do
+      let(:key) { "rules.#{namespace}.name" }
+      subject { messages.key?(key, {locale: :en}) }
+
+      it { expect(subject).to be_truthy }
+    end
+
+    describe '#get' do
+      let(:key) { "rules.#{namespace}.name" }
+      subject { messages.get(key, {locale: :en}) }
+
+      it { expect(subject).to eq('Name') }
+    end
+
+    after(:all) do
+      I18n.locale = I18n.default_locale
+    end
+  end
+end

--- a/spec/integration/messages/yaml_spec.rb
+++ b/spec/integration/messages/yaml_spec.rb
@@ -1,0 +1,27 @@
+require 'dry/validation/messages/abstract'
+
+RSpec.describe Messages::YAML do
+  subject(:messages) { Messages::YAML.new(Messages::YAML.load_file(path)) }
+
+  let(:path) { SPEC_ROOT.join('fixtures/locales/en.yml') }
+
+  describe '#rule' do
+    subject { messages.rule('email') }
+
+    it { expect(subject).to eq('E-mail') }
+  end
+
+  describe '#key?' do
+    let(:key) { '%{locale}.rules.email' }
+    subject { messages.key?(key, {locale: :en}) }
+
+    it { expect(subject).to be_truthy }
+  end
+
+  describe '#get' do
+    let(:key) { '%{locale}.rules.email' }
+    subject { messages.get(key, {locale: :en}) }
+
+    it { expect(subject).to eq('E-mail') }
+  end
+end


### PR DESCRIPTION
### What

Added method `rule_path` for `Messages::Abstract` and `Messages::YAML`. Because path for  `Messages::I18n` and `Messages::YAML` should be different.

For `Messages::I18n` we should have key like `"rules.#{name}"`. Because 
```
      def key?(key, options)
        ::I18n.exists?(key, options.fetch(:locale, default_locale)) ||
        ::I18n.exists?(key, I18n.default_locale)
      end
```
will not find key like `%{locale}.rules...`.

For `Messages::YAML` it should be `"%{locales}.rules.#{name}"`. Because
```
      def key?(key, options = {})
        data.key?(key % { locale: options.fetch(:locale, default_locale) })
      end
```

For `Messages::Namespaced` it will be build based on `messages` class.

### Related Issue

https://github.com/dry-rb/dry-validation/issues/353