### PR TITLE
Make hash work for arguments for predicates

### DIFF
--- a/lib/dry/validation/message_compiler.rb
+++ b/lib/dry/validation/message_compiler.rb
@@ -173,6 +173,10 @@ module Dry
       def message_tokens(args)
         args.each_with_object({}) { |arg, hash|
           case arg[1]
+          when Hash
+            arg[1].each do |k, v|
+              hash[k] = v
+            end
           when Array
             hash[arg[0]] = arg[1].join(LIST_SEPARATOR)
           when Range

--- a/lib/dry/validation/messages/abstract.rb
+++ b/lib/dry/validation/messages/abstract.rb
@@ -32,6 +32,7 @@ module Dry
         setting :val_type_default, 'default'.freeze
 
         setting :arg_types, Hash.new { |*| config.arg_type_default }.update(
+          Hash => 'hash',
           Range => 'range'
         )
 


### PR DESCRIPTION
Hey, I've had problem with autogenerating error messages when validating image dimensions with dry-validate.

Problem is that there are 2 values validates at the same time (both height & width) and somehow messages cannot interpolate this properly.

Here's how I use it

```ruby
# predicate
predicate(:image_dimensions_gt?) do |dimensions, file|
  image_width_gt?(dimensions[:min_width], file) && image_height_gt?(dimensions[:min_height], file)
end

predicate(:image_width_gt?) do |min_width, file|
  minimagick_image(file).width >= min_width
end

predicate(:image_height_gt?) do |min_height, file|
   minimagick_image(file).height >= min_height
end

def self.minimagick_image(file)
  MiniMagick::Image.open(file.tempfile.path)
rescue MiniMagick::Invalid
  nil
end

# validation
required(:file).filled(:image?,
                       image_dimensions_gt?: {
                         min_width: Db::GalleryPicture::MIN_WIDTH,
                         min_height: Db::GalleryPicture::MIN_HEIGHT
                       })
```

```yml
# translation
image_dimensions_gt?:
  arg:
    default: '{ "key": "validation.min_image_dimensions" }}'
    hash: '{ "key": "validation.image_dimensions_gt", "placeholders": { "min_width": "%{min_width}", "min_height": "%{min_height}" } }'
```

Not sure whether that's best possible solution, I am open to any feedback :)