### PR TITLE
Suppress interpolation warnings

### DIFF
--- a/lib/dry/validation/message_compiler.rb
+++ b/lib/dry/validation/message_compiler.rb
@@ -160,6 +160,8 @@ module Dry
       end
 
       def message_text(rule, template, tokens, opts)
+        original_verbosity = $VERBOSE
+        $VERBOSE = nil
         text = template % tokens
 
         if full?
@@ -168,6 +170,8 @@ module Dry
         else
           text
         end
+      ensure
+        $VERBOSE = original_verbosity
       end
 
       def message_tokens(args)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ end
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+  config.warnings = true
 
   config.after do
     if defined?(I18n)


### PR DESCRIPTION
This is a workaround which suppresses warnings issued by Kernel.sprintf in
presence of extra keys when interpolating a template string. Now, dry-v won't
pollute other projects with a ton of useless warnings. I did some research
on the subject and found out that:

1. The current behavior of MRI is not going to change anytime soon
  https://bugs.ruby-lang.org/issues/2709
  https://bugs.ruby-lang.org/issues/5763

2. What i18n did about this
  a) ignored warnings
  b) implemented interpolation in pure Ruby
  c) added efficient interpolation compiler (this is kinda unrelated but since
     it improves the performance we can have it too to compensate the slowdown
     caused by implementing "sprintf" in Ruby)

  https://github.com/svenfuchs/i18n/issues/65
  https://github.com/svenfuchs/i18n/blob/0a0fa8e5e7f4497e0c39c046b2a94470caf3eb3a/lib/i18n/backend/interpolation_compiler.rb

This commit is step 2a, we then should take 2b and decide whether we need 2c or
not (because we could just use i18n instead).

/cc @solnic @jodosha 