### PR TITLE
Rename Result#to_either to #to_monad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 
+* `Result#to_either` was renamed to `#to_monad`, the previous name is kept for backward compatibility (flash-gordon)
 * [internal] fix warnings from dry-types v0.12.0
 
 [Compare v0.11.0...v0.11.1](https://github.com/dry-rb/dry-validation/compare/v0.11.0...v0.11.1)

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :test do
     gem 'codeclimate-test-reporter', require: false
     gem 'simplecov', require: false
   end
-  gem 'dry-monads', require: false
+  gem 'dry-monads', '>= 0.4.0', require: false
   gem 'dry-struct', require: false
 end
 

--- a/lib/dry/validation/extensions/monads.rb
+++ b/lib/dry/validation/extensions/monads.rb
@@ -1,17 +1,18 @@
-require 'dry/monads/either'
+require 'dry/monads/result'
 
 module Dry
   module Validation
     class Result
-      include Dry::Monads::Either::Mixin
+      include Dry::Monads::Result::Mixin
 
-      def to_either(options = EMPTY_HASH)
+      def to_monad(options = EMPTY_HASH)
         if success?
-          Right(output)
+          Success(output)
         else
-          Left(messages(options))
+          Failure(messages(options))
         end
       end
+      alias_method :to_either, :to_monad
     end
   end
 end

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe Dry::Validation::Result do
   context 'with valid input' do
     let(:input) { { name: 'Jane' } }
 
-    describe '#to_either' do
-      it 'returns a Right instance' do
-        either = result.to_either
+    describe '#to_monad' do
+      it 'returns a Success value' do
+        monad = result.to_monad
 
-        expect(either).to be_right
-        expect(either.value).to eql(name: 'Jane')
+        expect(monad).to be_a Dry::Monads::Result
+        expect(monad).to be_a_success
+        expect(monad.value!).to eql(name: 'Jane')
       end
     end
   end
@@ -19,19 +20,20 @@ RSpec.describe Dry::Validation::Result do
   context 'with invalid input' do
     let(:input) { { name: '' } }
 
-    describe '#to_either' do
-      it 'returns a Left instance' do
-        either = result.to_either
+    describe '#to_monad' do
+      it 'returns a Failure value' do
+        monad = result.to_monad
 
-        expect(either).to be_left
-        expect(either.value).to eql(name: ['must be filled', 'length must be within 2 - 4'])
+        expect(monad).to be_a_failure
+        expect(monad.failure).to eql(name: ['must be filled', 'length must be within 2 - 4'])
       end
 
       it 'returns full messages' do
-        either = result.to_either(full: true)
+        monad = result.to_monad(full: true)
 
-        expect(either).to be_left
-        expect(either.value).to eql(name: ['name must be filled', 'name length must be within 2 - 4'])
+        expect(monad).to be_a Dry::Monads::Result
+        expect(monad).to be_a_failure
+        expect(monad.failure).to eql(name: ['name must be filled', 'name length must be within 2 - 4'])
       end
     end
   end


### PR DESCRIPTION
Keeping it in sync with the latest changes in dry-monads, as in, `Either` became `Result`. Since having `Result#to_result` would be awkward I chose `#to_monad` instead.