### PR TITLE
Fixed bug with nested input for custom validation block

### DIFF
--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -115,7 +115,7 @@ module Dry
         end
 
         def validate(**opts, &block)
-          id, *deps = opts.to_a.flatten
+          id, *deps = opts.to_a.flatten(2)
           name = deps.size > 1 ? id : deps.first
           rule = create_rule([:check, [deps, [:custom, [id, block]]]], name).with(deps: deps)
           add_check(rule)


### PR DESCRIPTION
This is a small fix for nested values in a custom validation block. 

```
require(:newsletter).value(:bool?)
require(:user).schema do
  require(:email).maybe(:str?)
end

validate(email_required: [:newsletter, [:user, :email]]) do |newsletter, email|
  ...
end
```

The `validate` method didn't process the path(as array of symbols) correctly for the nested values.