### PR TITLE
Add option to return message_set as failure case in monads extension

### DIFF
--- a/lib/dry/validation/extensions/monads.rb
+++ b/lib/dry/validation/extensions/monads.rb
@@ -5,11 +5,15 @@ module Dry
     class Result
       include Dry::Monads::Result::Mixin
 
-      def to_monad(options = EMPTY_HASH)
+      def to_monad(failure_value_as_message_set: false, **options)
         if success?
           Success(output)
         else
-          Failure(messages(options))
+          if failure_value_as_message_set
+            Failure(message_set(options))
+          else
+            Failure(messages(options))
+          end
         end
       end
       alias_method :to_either, :to_monad

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe Dry::Validation::Result do
         expect(monad).to be_a_failure
         expect(monad.failure).to eql(name: ['name must be filled', 'name length must be within 2 - 4'])
       end
+
+      it 'returns message set as Failure value' do
+        monad = result.to_monad(failure_value_as_message_set: true)
+
+        expect(monad).to be_a Dry::Monads::Result
+        expect(monad).to be_a_failure
+        expect(monad.failure).to be_a Dry::Validation::MessageSet
+        expect(monad.failure.dump).to eql(name: ['must be filled', 'length must be within 2 - 4'])
+      end
     end
   end
 end


### PR DESCRIPTION
Hi! I needed access to the underlying message_set in the failure case of the Result monad, so I made this quick change. Is this adequate?

PS: By the way I noticed the monads extension isn't documented, is this something I could work on?
