### PR TITLE
Confirmation with type specs

### DIFF
--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -99,7 +99,7 @@ module Dry
         def confirmation
           conf = :"#{name}_confirmation"
 
-          parent.optional(conf).maybe
+          parent.optional(conf, type_map[name]).maybe
 
           rule(conf => [conf, name]) do |left, right|
             left.eql?(right)


### PR DESCRIPTION
An attempt to solve my own issue with confirmations not working with type_specs. (#367)

Please note that I have little knowledge of what states `type_map[name]` can be in – this is the way I saw to get access to the type_spec of the current rule, there might be better/safer ways! No specs seems to be failing though.