### PR TITLE
Return correct rule name while using i18n

### DIFF
--- a/lib/dry/validation/messages/i18n.rb
+++ b/lib/dry/validation/messages/i18n.rb
@@ -17,6 +17,11 @@ module Dry
         t.(key, options) if key
       end
 
+      def rule(name, options = {})
+        path = "rules.#{name}"
+        get(path, options) if key?(path, options)
+      end
+
       def key?(key, options)
         ::I18n.exists?(key, options.fetch(:locale, default_locale)) ||
         ::I18n.exists?(key, I18n.default_locale)

--- a/spec/fixtures/locales/pl.yml
+++ b/spec/fixtures/locales/pl.yml
@@ -16,3 +16,7 @@ pl:
         rules:
           email:
             filled?: "Hej user! Dawaj ten email no!"
+
+  rules:
+    email:
+      'Adres email'

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe Messages::I18n do
       end
     end
 
+    context 'rule name translations' do
+      it 'translates rule name and its message' do
+        msg = messages.rule('email')
+
+        expect(msg).to eql('Adres email')
+      end
+    end
+
     context 'with a different locale' do
       it 'returns a message for a predicate' do
         message = messages[:filled?, rule: :name, locale: :en]

--- a/spec/integration/messages/i18n_spec.rb
+++ b/spec/integration/messages/i18n_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Messages::I18n do
     end
 
     context 'rule name translations' do
-      it 'translates rule name and its message' do
+      it 'translates rule name' do
         msg = messages.rule('email')
 
         expect(msg).to eql('Adres email')


### PR DESCRIPTION
Currently, rules translations don't work when i18n is enabled.