### PR TITLE
[Issue #358] updated pull request to work with 0.12.2

### DIFF
--- a/lib/dry/validation/schema/class_interface.rb
+++ b/lib/dry/validation/schema/class_interface.rb
@@ -64,7 +64,8 @@ module Dry
           cfg.rules = rules
           cfg.checks = cfg.checks + dsl.checks
           cfg.path = dsl.path
-          cfg.type_map = target.build_type_map(dsl.type_map) if cfg.type_specs
+          cfg.type_map = target.
+            build_inherited_type_map(dsl.type_map, config.type_map) if cfg.type_specs
         end
 
         target

--- a/lib/dry/validation/type_specs.rb
+++ b/lib/dry/validation/type_specs.rb
@@ -10,6 +10,34 @@ module Dry
         end
       end
 
+      def build_inherited_type_map(type_specs, inherited_specs)
+        build_type_map(
+          if Array === type_specs
+            if inherited_specs.empty?
+              type_specs
+            elsif Dry::Types::Safe === inherited_specs
+              raise InvalidSchemaError,
+                "Composition of array schema type_maps not supported when config.type_specs = true"
+            else
+              raise InvalidSchemaError,
+                "Extending non-array schema with an array type_map not supported when config.type_specs = true"
+            end
+          elsif Dry::Types::Safe === inherited_specs
+            if type_specs.empty?
+              inherited_specs
+            elsif Array === type_specs
+              raise InvalidSchemaError,
+                "Composition of array schema type_maps not supported when config.type_specs = true"
+            else
+              raise InvalidSchemaError,
+                "Extending array schema with a non-array type_map not supported when config.type_specs = true"
+            end
+          else
+            inherited_specs.merge(type_specs)
+          end
+        )
+      end
+
       def build_type_map(type_specs, category = config.input_processor)
         if type_specs.is_a?(Array)
           build_array_type(type_specs[0], category)

--- a/spec/integration/schema/params/explicit_types_spec.rb
+++ b/spec/integration/schema/params/explicit_types_spec.rb
@@ -192,4 +192,78 @@ RSpec.describe Dry::Validation::Schema::Params, 'explicit types' do
       )
     end
   end
+
+  context 'inherited schema' do
+    subject(:base_schema) do
+      Dry::Validation.Params do
+        configure { config.type_specs = true }
+        required(:email, :string)
+      end
+    end
+     subject(:schema) do
+      Dry::Validation.Schema(base_schema) do
+        required(:age, :integer)
+      end
+    end
+     it 'uses form coercion for nested input' do
+      input = {
+        'email' => 'jane@doe.org',
+        'age' => '21'
+      }
+       expect(schema.(input).to_h).to eql(
+        email: 'jane@doe.org',
+        age: 21
+      )
+    end
+   end
+
+  context 'inherited schema with arrays: hash extends nonempty array' do
+    subject(:base_schema) do
+      Dry::Validation.Params do
+        configure { config.type_specs = true }
+        each { required(:email, :string) }
+      end
+    end
+     subject(:schema) do
+      Dry::Validation.Schema(base_schema) do
+        required(:age, :int)
+      end
+    end
+     it 'uses form coercion for nested input' do
+      expect { schema }.to raise_error InvalidSchemaError
+    end
+  end
+
+  context 'inherited schema with arrays: array extends empty hash' do
+    subject(:base_schema) do
+      Dry::Validation.Params do
+        configure { config.type_specs = true }
+      end
+    end
+     subject(:schema) do
+      Dry::Validation.Schema(base_schema) do
+        each { required(:age, :integer) }
+      end
+    end
+     it 'uses form coercion for nested input' do
+      expect { schema }.to_not raise_error
+    end
+  end
+
+  context 'inherited schema with arrays: array extends nonempty hash' do
+    subject(:base_schema) do
+      Dry::Validation.Params do
+        configure { config.type_specs = true }
+        required(:email, :string)
+      end
+    end
+     subject(:schema) do
+      Dry::Validation.Schema(base_schema) do
+        each { required(:age, :integer) }
+      end
+    end
+     it 'uses form coercion for nested input' do
+      expect { schema }.to raise_error InvalidSchemaError
+    end
+  end
 end


### PR DESCRIPTION
I updated previous pull request (https://github.com/dry-rb/dry-validation/pull/359) to work with 0.12.2.

Issues 358 (https://github.com/dry-rb/dry-validation/issues/358) and 424 (https://github.com/dry-rb/dry-validation/issues/424) seem critical, since it is impossible to use dry-validation with large schemas.