### PR TITLE
Fix using optional string keys when using sanitizer

### DIFF
--- a/lib/dry/validation/input_processor_compiler.rb
+++ b/lib/dry/validation/input_processor_compiler.rb
@@ -76,7 +76,7 @@ module Dry
 
         key = visit(left)
 
-        if key.is_a?(Symbol)
+        if key.is_a?(Symbol) || key.is_a?(String)
           [:member, [key, visit(right, false)]]
         else
           [:sum, [key, visit(right, false), {}]]

--- a/spec/integration/schema/input_processor_spec.rb
+++ b/spec/integration/schema/input_processor_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Dry::Validation::Schema, 'setting input processor in schema' do
         required(:prefix).filled
         required(:value).filled
       end
+
+      optional('height').filled
     end
   end
 
@@ -30,7 +32,8 @@ RSpec.describe Dry::Validation::Schema, 'setting input processor in schema' do
       phone_numbers: [
         { prefix: '48', value: '123' },
         { lol: '!!', prefix: '1', value: '312' }
-      ]
+      ],
+      'height' => 165
     )
 
     expect(result.output).to eql(
@@ -40,7 +43,8 @@ RSpec.describe Dry::Validation::Schema, 'setting input processor in schema' do
       phone_numbers: [
         { prefix: '48', value: '123' },
         { prefix: '1', value: '312' }
-      ]
+      ],
+      'height' => 165
     )
   end
 end


### PR DESCRIPTION
Previously using `optional('height').filled` produced
```
  NoMethodError:
    undefined method `visit_height' for #<Dry::Types::Compiler:0x007fdf3f9eb530 @registry=Dry::Types>
```
when the input_processor was set to sanitizer.

Input processor compiler was checking only if the key was a symbol. Now
it also checks for string keys.

Fixes #386