### PR TITLE
⚠ method redefined; discarding old schema

### DIFF
--- a/lib/dry/validation/schema/value.rb
+++ b/lib/dry/validation/schema/value.rb
@@ -4,7 +4,7 @@ module Dry
   module Validation
     class Schema
       class Value < DSL
-        attr_reader :type, :schema_class, :schema, :type_map
+        attr_reader :type, :schema_class, :type_map
 
         def initialize(options = {})
           super


### PR DESCRIPTION
The ruby interpreter warns when loading line 42. This reproduces with
```
% ruby -rdry-validation -wep
```
with current 0.12.2 gem.