### PR TITLE
Builds better schema rules from Dry::Struct (StructClassBuilder)

### DIFF
--- a/spec/extensions/struct/schema_spec.rb
+++ b/spec/extensions/struct/schema_spec.rb
@@ -29,4 +29,140 @@ RSpec.describe Dry::Validation::Schema, 'defining schema using dry struct' do
       person: { name: { family_name: ['is missing', 'must be String'] } }
     )
   end
+
+  context 'when nested struct fields are omittable' do
+    subject(:schema) do
+      Dry::Validation.Schema do
+        required(:book).schema(Test::Book)
+      end
+    end
+
+    before do
+      class Test::Author < Dry::Struct::Value
+        attribute :name, Dry::Types['strict.string']
+        attribute :age, Dry::Types['strict.integer'].meta(omittable: true)
+      end
+
+      class Test::Book < Dry::Struct::Value
+        attribute :author, Test::Author.meta(omittable: true)
+      end
+    end
+
+    it 'does not fail when omittable fields are omitted' do
+      expect(schema.call(book: {})).to be_success
+    end
+
+    it 'does not fail when nested omittable fields are omitted' do
+      expect(schema.call(book: { author: { name: 'Toby' } })).to be_success
+    end
+  end
+
+  context 'when nested struct field is arrays of structs' do
+    subject(:schema) do
+      Dry::Validation.Schema do
+        required(:category).schema(Test::Category)
+      end
+    end
+
+    before do
+      class Test::Product < Dry::Struct::Value
+        attribute :name, Dry::Types['strict.string']
+        attribute :sku, Dry::Types['strict.integer']
+        attribute :size, Dry::Types['strict.string'].meta(omittable: true)
+      end
+
+      class Test::Category < Dry::Struct::Value
+        attribute :products, Dry::Types['strict.array'].of(Test::Product)
+      end
+    end
+
+    it 'allows an empty array' do
+      expect(schema.call(category: { products: [] })).to be_success
+    end
+
+    it 'does not fail when omittable fields are omitted' do
+      expect(
+        schema.call(
+          category: {
+            products: [
+              {
+                name: 'Thing',
+                sku: 123
+              }
+            ]
+          }
+        )
+      ).to be_success
+    end
+
+    it 'fails when nested array member schema input is invalid' do
+      expect(
+        schema.call(
+          category: {
+            products: [
+              {
+                name: 'Thing',
+                sku: 123,
+                size: 1
+              }
+            ]
+          }
+        ).messages
+      ).to eq(
+        category: {
+          products: {
+            0 => {
+              size: [
+                'must be String'
+              ]
+            }
+          }
+        }
+      )
+    end
+  end
+
+  context 'when nested struct field is arrays of structs' do
+    subject(:schema) do
+      Dry::Validation.Schema do
+        required(:package).schema(Test::Package)
+      end
+    end
+
+    before do
+      class Test::PriceSet < Dry::Struct::Value
+        attribute :prices, Dry::Types['strict.array'].of(Dry::Types['strict.integer'])
+      end
+
+      class Test::Package < Dry::Struct::Value
+        attribute :price_set, Test::PriceSet
+      end
+    end
+
+    it 'succeeds when input is valid' do
+      expect(schema.call(package: { price_set: { prices: [1, 2] } })).to be_success
+    end
+
+    it 'fails when nested array member is not valid type' do
+      expect(
+        schema.call(
+          package: {
+            price_set: {
+              prices: ['1']
+            }
+          }
+        ).messages
+      ).to eq(
+        package: {
+          price_set: {
+            prices: {
+              0 => [
+                'must be Integer'
+              ]
+            }
+          }
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
Struct Extensions (`Dry::Validation.load_extensions(:struct)`)

Dry::Struct can be used in schema validation with the `.schema(`, `.filled(` method to define a nested structure that should validate (satisfy) a predefined Dry::Struct.

The issue addressed here is that there are some assumptions baked into the StructClassBuilder that has several unintuitive behaviors:

https://github.com/dry-rb/dry-validation/blob/88cb4fb38add9abecfee4a5bae09d2a07fd90e80/lib/dry/validation/extensions/struct.rb#L6-L16

1. all keys are declared as `required`, which ignores the meta[:omittable] metadata declared on the struct field type
2. all keys' values are assumed as `.filled`, which may not be the case and ignores the Struct field's Type coercible and `optional` settings
3. Structs with Array-type fields don't validate the array members properly, as noted in #396 (https://github.com/dry-rb/dry-validation/pull/396)
4. Structs with Array-type fields aren't allowed to be empty, which a Struct allows.

I'm in agreement about not using structs to validate, but it seems like this functionality was at least somewhat intended as the extension exists today. If this is unwanted there's already a workaround--define your schema validation separately from your struct. Doing so means
a good deal of duplicating the type information between the schema and the struct.

This modifies the StructClassBuilder to build a schema more intelligently, by respecting `omittable` and handling arrays of types and other nested structs. The time complexity seems similar in that this
is as recursive as the previous implementation, with the exception that this has a few easy conditionals.