### PR TITLE
Implemented .build shortcut

### DIFF
--- a/lib/dry/validation/contract/class_interface.rb
+++ b/lib/dry/validation/contract/class_interface.rb
@@ -29,6 +29,7 @@ module Dry
           @__messages__ ||= Messages.setup(config)
         end
 
+        # @api private
         def build(option = nil, &block)
           Class.new(self, &block).new(option)
         end

--- a/lib/dry/validation/contract/class_interface.rb
+++ b/lib/dry/validation/contract/class_interface.rb
@@ -28,6 +28,10 @@ module Dry
         def messages
           @__messages__ ||= Messages.setup(config)
         end
+
+        def build(option = nil, &block)
+          Class.new(self, &block).new(option)
+        end
       end
     end
   end

--- a/spec/integration/contract/build_spec.rb
+++ b/spec/integration/contract/build_spec.rb
@@ -1,0 +1,15 @@
+require 'dry/validation/contract'
+
+RSpec.describe Dry::Validation::Contract, '.build' do
+  subject(:contract) do
+    Dry::Validation::Contract.build do
+      params do
+        required(:email).filled(:string)
+      end
+    end
+  end
+
+  it "return instance of Dry::Validation::Contract" do
+    expect(contract).to be_a(Dry::Validation::Contract)
+  end
+end


### PR DESCRIPTION
Added `.build` to `Dry::Validation::Contract`.
It is just a shortcut that can be used to define contracts that won't be reused or inherited.