### PR TITLE
Expand rule API

### DIFF
--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -103,10 +103,10 @@ module Dry
       def call(input)
         Result.new(schema.(input)) do |result|
           rules.each do |rule|
-            next if result.error?(rule.name)
+            next if rule.keys.any? { |key| result.error?(key) }
 
             rule_result = rule.(self, result)
-            result.add_error(rule.name, rule_result.message) if rule_result.failure?
+            result.add_error(*rule_result.message) if rule_result.failure?
           end
         end
       end

--- a/lib/dry/validation/contract/class_interface.rb
+++ b/lib/dry/validation/contract/class_interface.rb
@@ -57,8 +57,8 @@ module Dry
         # @return [Array<Rule>]
         #
         # @api public
-        def rule(name, &block)
-          rules << Rule.new(name: name, block: block)
+        def rule(*keys, &block)
+          rules << Rule.new(keys: keys, block: block)
           rules
         end
 

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -18,10 +18,15 @@ module Dry
       #   @api private
       param :context
 
-      # @!attribute [r] name
-      #   @return [Symbol]
+      # @!attribute [r] keys
+      #   @return [Array<String, Symbol, Hash>]
       #   @api private
-      option :name
+      option :keys
+
+      # @!attribute [r] default_id
+      #   @return [String, Symbol, Hash]
+      #   @api private
+      option :default_id, default: proc { keys.first }
 
       # @!attribute [r] values
       #   @return [Object]
@@ -56,14 +61,17 @@ module Dry
       #
       # @api public
       def failure(msg_or_key, **tokens)
-        @message =
+        id, text =
           case msg_or_key
           when Symbol
-            context.message(msg_or_key, rule: name, tokens: tokens)
+            [default_id, context.message(msg_or_key, rule: default_id, tokens: tokens)]
           when String
+            [default_id, msg_or_key]
+          when Array
             msg_or_key
           end
         @failure = true
+        @message = [id, text]
         self
       end
 

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -11,10 +11,10 @@ module Dry
 
       extend Dry::Initializer
 
-      # @!atrribute [r] name
-      #   @return [Symbol]
+      # @!atrribute [r] keys
+      #   @return [Array<Symbol, String, Hash>]
       #   @api private
-      option :name
+      option :keys
 
       # @!atrribute [r] block
       #   @return [Proc]
@@ -28,7 +28,7 @@ module Dry
       #
       # @api private
       def call(context, values)
-        Evaluator.new(context, values: values, name: name, &block)
+        Evaluator.new(context, values: values, keys: keys, &block)
       end
     end
   end

--- a/spec/integration/contract/class_interface/rule_spec.rb
+++ b/spec/integration/contract/class_interface/rule_spec.rb
@@ -1,0 +1,38 @@
+require 'dry/validation/contract'
+
+RSpec.describe Dry::Validation::Contract, '.rule' do
+  subject(:contract) { contract_class.new }
+
+  let(:contract_class) do
+    Class.new(Dry::Validation::Contract) do
+      params do
+        required(:email).filled(:string)
+        optional(:login).maybe(:string, :filled?)
+      end
+    end
+  end
+
+  context 'when the name matches one of the keys' do
+    before do
+      contract_class.rule(:login) do
+        failure('is too short') if values[:login].size < 3
+      end
+    end
+
+    it 'applies rule when value passed schema checks' do
+      expect(contract.(email: 'jane@doe.org', login: 'ab').errors).to eql(login: ['is too short'])
+    end
+  end
+
+  context 'when the name does not match one of the keys' do
+    before do
+      contract_class.rule(:custom) do
+        failure('this works')
+      end
+    end
+
+    it 'applies the rule regardless of the schema result' do
+      expect(contract.(email: 'jane@doe.org', login: 'jane').errors).to eql(custom: ['this works'])
+    end
+  end
+end

--- a/spec/integration/contract/class_interface/rule_spec.rb
+++ b/spec/integration/contract/class_interface/rule_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
     Class.new(Dry::Validation::Contract) do
       params do
         required(:email).filled(:string)
-        optional(:login).maybe(:string, :filled?)
+        optional(:login).filled(:string)
       end
     end
   end
@@ -33,6 +33,19 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
 
     it 'applies the rule regardless of the schema result' do
       expect(contract.(email: 'jane@doe.org', login: 'jane').errors).to eql(custom: ['this works'])
+    end
+  end
+
+  context 'with a list of keys' do
+    before do
+      contract_class.rule(:email, :login) do
+        failure(:login, 'is not needed when email is provided') if email.size > 0 && login.size > 0
+      end
+    end
+
+    it 'applies the rule when all values passed schema checks' do
+      expect(contract.(email: nil, login: nil).errors)
+        .to eql(email: ['must be a string'], login: ['must be a string'])
     end
   end
 end

--- a/spec/integration/contract/inherited_spec.rb
+++ b/spec/integration/contract/inherited_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Dry::Validation::Contract, '.inherited' do
   end
 
   it 'inherits rules' do
-    expect(child_class.rules.map(&:name).sort).to eql(%i[email name])
+    expect(child_class.rules.map(&:keys).sort).to eql([[:email], [:name]])
   end
 
   it 'inherits configuration' do

--- a/spec/integration/evaluator_spec.rb
+++ b/spec/integration/evaluator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Dry::Validation::Evaluator do
   end
 
   let(:options) do
-    { name: :email, values: values }
+    { keys: [:email], values: values }
   end
 
   let(:values) do
@@ -23,7 +23,7 @@ RSpec.describe Dry::Validation::Evaluator do
     end
 
     it 'sets a failure message' do
-      expect(evaluator.message).to eql('oops')
+      expect(evaluator.message).to eql([:email, 'oops'])
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe Dry::Validation::Evaluator do
 
     it 'delegates to the context' do
       expect(context).to receive(:works?).and_return(true)
-      expect(evaluator.message).to eql('it works')
+      expect(evaluator.message).to eql([:email, 'it works'])
     end
   end
 end


### PR DESCRIPTION
Adds support for the following syntax:

``` ruby
rule(:email, :login) do
  failure("not valid") # defaults to using :email as the error identifier
end

rule(:email, :login) do
  failure(:foo, "not valid") # sets :foo as the error identifier
end
```

When more than one key is provided, rule will be applied only if all values passed schema checks.