### PR TITLE
Add :monads extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gemspec
 gem 'dry-schema', git: 'https://github.com/dry-rb/dry-schema', branch: 'master'
 
 group :test do
-  gem 'i18n', require: false
   gem 'dry-monads', '~> 1.0'
+  gem 'i18n', require: false
   gem 'simplecov', require: false, platform: :mri
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'dry-schema', git: 'https://github.com/dry-rb/dry-schema', branch: 'master'
 
 group :test do
   gem 'i18n', require: false
+  gem 'dry-monads', '~> 1.0'
   gem 'simplecov', require: false, platform: :mri
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,17 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), 'lib'))
 require 'rspec/core'
 require 'rspec/core/rake_task'
 
-task default: :spec
-
 desc 'Run all specs in spec directory'
-RSpec::Core::RakeTask.new(:spec)
+task :run_specs do
+  core_result = RSpec::Core::Runner.run(['spec/integration'])
+  RSpec.clear_examples
+
+  Dir[SPEC_ROOT.join('shared/**/*.rb')].each(&method(:load))
+
+  Dry::Validation.load_extensions(:monads)
+  ext_result = RSpec::Core::Runner.run(['spec'])
+
+  exit [core_result, ext_result].max
+end
+
+task default: :run_specs

--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -1,3 +1,16 @@
 # frozen_string_literal: true
 
 require 'dry/validation/contract'
+
+module Dry
+  # Main library namespace
+  #
+  # @api private
+  module Validation
+    extend Dry::Core::Extensions
+
+    register_extension(:monads) do
+      require 'dry/validation/extensions/monads'
+    end
+  end
+end

--- a/lib/dry/validation/extensions/monads.rb
+++ b/lib/dry/validation/extensions/monads.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'dry/monads/result'
+
+module Dry
+  module Validation
+    # Monad extension for contract results
+    #
+    # @example
+    #   Dry::Validation.load_extensions(:monads)
+    #
+    #   contract = Dry::Validation::Contract.build do
+    #     schema do
+    #       required(:name).filled(:string)
+    #     end
+    #   end
+    #
+    #   contract.call(name: nil).to_monad
+    #
+    # @api public
+    class Result
+      include Dry::Monads::Result::Mixin
+
+      # Returns a result monad
+      #
+      # @return [Dry::Monads::Result]
+      #
+      # @api public
+      def to_monad
+        success? ? Success(to_h) : Failure(self)
+      end
+    end
+  end
+end

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -38,6 +38,13 @@ module Dry
         @errors = errors.update(values.errors)
       end
 
+      # Return all messages including hints from schema
+      #
+      # @api public
+      def messages
+        values.messages
+      end
+
       # Check if result is successful
       #
       # @return [Bool]

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Validation::Result do
+  before { Dry::Validation.load_extensions(:monads) }
+
+  let(:schema) do
+    Class.new(Dry::Validation::Contract) do
+      schema do
+        required(:name).filled(:string, size?: 2..4)
+      end
+    end.new
+  end
+
+  let(:result) { schema.(input) }
+
+  context 'with valid input' do
+    let(:input) { { name: 'Jane' } }
+
+    describe '#to_monad' do
+      it 'returns a Success value' do
+        monad = result.to_monad
+
+        expect(monad).to be_a Dry::Monads::Result
+        expect(monad).to be_a_success
+        expect(monad.value!).to eql(name: 'Jane')
+      end
+    end
+  end
+
+  context 'with invalid input' do
+    let(:input) { { name: '' } }
+
+    describe '#to_monad' do
+      it 'returns a Failure value' do
+        monad = result.to_monad
+
+        expect(monad).to be_a_failure
+        expect(monad.failure.messages).to eql(name: ['must be filled', 'length must be within 2 - 4'])
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,8 @@ end
 require 'i18n'
 require 'dry/validation'
 
+Dry::Schema.load_extensions(:hints)
+
 SPEC_ROOT = Pathname(__dir__)
 
 Dir[SPEC_ROOT.join('shared/**/*.rb')].each(&method(:require))


### PR DESCRIPTION
This is similar to monads in dry-validation 0.x but now failure/success
objects wrap entire result, not just data or errors.

/cc @timriley 