### PR TITLE
Add support for base errors not associated with any key

### DIFF
--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -119,12 +119,18 @@ module Dry
       # @return [String]
       #
       # @api private
+      #
+      # rubocop:disable Metrics/AbcSize
       def message(key, tokens: EMPTY_HASH, **opts)
         msg_opts = opts.merge(tokens)
-        rule_path = Array(opts.fetch(:rule)).flatten
+        rule_path = Array(opts.fetch(:path)).flatten.compact
 
-        template = messages[key, msg_opts.merge(rule: rule_path.join(DOT))]
-        template ||= messages[key, msg_opts.merge(rule: rule_path.last)]
+        if rule_path.empty?
+          template = messages["rules.#{key}"]
+        else
+          template = messages[key, msg_opts.merge(rule: rule_path.join(DOT))]
+          template ||= messages[key, msg_opts.merge(rule: rule_path.last)]
+        end
 
         unless template
           raise MissingMessageError, <<~STR
@@ -134,6 +140,7 @@ module Dry
 
         Error.new(template.(template.data(tokens)), rule: key, path: rule_path)
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/lib/dry/validation/error.rb
+++ b/lib/dry/validation/error.rb
@@ -32,6 +32,15 @@ module Dry
         @rule = rule || @path.last
       end
 
+      # Check if this is a base error not associated with any key
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def base?
+        @base ||= path.size.equal?(0)
+      end
+
       # Dump error to a string
       #
       # @return [String]

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -77,12 +77,12 @@ module Dry
           if args.size.equal?(1)
             case (msg = args[0])
             when Symbol
-              _context.message(msg, rule: default_id, tokens: tokens)
+              _context.message(msg, path: default_id, tokens: tokens)
             when String
-              Error.new(msg, rule: default_id, path: default_id)
+              Error.new(msg, path: default_id)
             end
           else
-            Error.new(args[1], rule: args[0], path: args[0])
+            Error.new(args[1], path: args[0])
           end
 
         @failure = true

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -52,6 +52,11 @@ module Dry
       end
       alias_method :messages, :errors
 
+      # @api public
+      def base_errors
+        error_set.filter(:base?).map(&:to_s)
+      end
+
       # Check if result is successful
       #
       # @return [Bool]

--- a/spec/fixtures/messages/errors.en.yml
+++ b/spec/fixtures/messages/errors.en.yml
@@ -2,6 +2,7 @@ en:
   dry_validation:
     errors:
       rules:
+        not_weekend: "this only works on weekends"
         email:
           invalid: "oh noez bad email"
           taken: "looks like %{email} is taken"

--- a/spec/integration/contract/class_interface/rule_spec.rb
+++ b/spec/integration/contract/class_interface/rule_spec.rb
@@ -88,6 +88,22 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
     end
   end
 
+  context 'with a rule that sets a general base error for the whole input' do
+    before do
+      contract_class.rule do
+        failure('this whole thing is invalid')
+      end
+    end
+
+    it 'sets a base error not attached to any key' do
+      expect(contract.(email: 'jane@doe.org', login: '').errors)
+        .to eql(login: ['must be filled'])
+
+      expect(contract.(email: 'jane@doe.org', login: '').base_errors)
+        .to eql(['this whole thing is invalid'])
+    end
+  end
+
   context 'with a list of keys' do
     before do
       contract_class.rule(:email, :login) do

--- a/spec/integration/contract/message_spec.rb
+++ b/spec/integration/contract/message_spec.rb
@@ -12,23 +12,28 @@ RSpec.describe Dry::Validation::Contract, '#message' do
       end
     end
 
+    it 'returns message text for base rule' do
+      expect(contract.message(:not_weekend, path: nil).to_s)
+        .to eql('this only works on weekends')
+    end
+
     it 'returns message text for flat rule' do
-      expect(contract.message(:taken, rule: :email, tokens: { email: 'jane@doe.org' }).to_s)
+      expect(contract.message(:taken, path: :email, tokens: { email: 'jane@doe.org' }).to_s)
         .to eql('looks like jane@doe.org is taken')
     end
 
     it 'returns message text for nested rule when it is defined under root' do
-      expect(contract.message(:invalid, rule: %i[address city]).to_s)
+      expect(contract.message(:invalid, path: %i[address city]).to_s)
         .to eql('is not a valid city name')
     end
 
     it 'returns message text for nested rule' do
-      expect(contract.message(:invalid, rule: %i[address street]).to_s)
+      expect(contract.message(:invalid, path: %i[address street]).to_s)
         .to eql("doesn't look good")
     end
 
     it 'raises error when template was not found' do
-      expect { contract.message(:not_here, rule: :email) }
+      expect { contract.message(:not_here, path: :email) }
         .to raise_error(Dry::Validation::MissingMessageError, <<~STR)
           Message template for :not_here under "email" was not found
         STR


### PR DESCRIPTION
Refs #469 

Adds support for defining rules w/o any path, so that their failures won't be associated with any key path or identifier, making them "base" errors associated with the entire input.

Here's an example:

``` ruby
# frozen_string_literal: true

require 'dry/validation/contract'
require 'byebug'

class NewUserContract < Dry::Validation::Contract
  params do
    required(:email).filled(:string)
  end

  rule do
    failure('Sorry, users can only sign up on weekends') unless weekend?
  end

  def weekend?
    %w[Sat Sun].include?(Date.today.strftime('%a'))
  end
end

contract = NewUserContract.new

puts contract.(email: '').errors.inspect
# {:email=>["must be filled"]}

puts contract.(email: '').base_errors.inspect
# ["Sorry, users can only sign up on weekends"]
```