### PR TITLE
Error set as the errors

### DIFF
--- a/lib/dry/validation/error.rb
+++ b/lib/dry/validation/error.rb
@@ -28,8 +28,9 @@ module Dry
       # @api private
       def initialize(text, path:, rule: nil)
         @text = text
-        @path = Array(path).flatten
+        @path = path ? Array(path).flatten : [nil]
         @rule = rule || @path.last
+        @base = path.nil?
       end
 
       # Check if this is a base error not associated with any key
@@ -38,7 +39,7 @@ module Dry
       #
       # @api public
       def base?
-        @base ||= path.size.equal?(0)
+        @base
       end
 
       # Dump error to a string

--- a/lib/dry/validation/error_set.rb
+++ b/lib/dry/validation/error_set.rb
@@ -51,18 +51,13 @@ module Dry
       private
 
       # @api private
-      def key_errors
-        reject { |error| error.path.empty? }
-      end
-
-      # @api private
       def unique_paths
-        key_errors.uniq(&:path).map(&:path)
+        uniq(&:path).map(&:path)
       end
 
       # @api private
       def messages_map
-        key_errors.reduce(placeholders) do |hash, msg|
+        reduce(placeholders) do |hash, msg|
           node = msg.path.reduce(hash) { |a, e| a.is_a?(Hash) ? a[e] : a.last[e] }
           (node.size > 1 ? node[0] : node) << msg.to_s
           hash

--- a/lib/dry/validation/error_set.rb
+++ b/lib/dry/validation/error_set.rb
@@ -11,8 +11,6 @@ module Dry
     #
     # @api public
     class ErrorSet < Schema::MessageSet
-      include Enumerable
-
       # Add a new error
       #
       # This is used when result is being prepared

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -29,32 +29,18 @@ module Dry
       #   @api private
       attr_reader :values
 
-      # @!attribute [r] error_set
+      # @!attribute [r] errors
       #   @return [ErrorSet]
       #   @api public
-      attr_reader :error_set
+      attr_reader :errors
+      alias_method :messages, :errors
 
       # Initialize a new result
       #
       # @api private
       def initialize(values)
         @values = values
-        @error_set = ErrorSet.new(values.message_set.to_a, failures: true)
-      end
-
-      # Return error hash
-      #
-      # @return [Hash<Symbol=>Array<String>>]
-      #
-      # @api public
-      def errors
-        error_set.to_h
-      end
-      alias_method :messages, :errors
-
-      # @api public
-      def base_errors
-        error_set.filter(:base?).map(&:to_s)
+        @errors = ErrorSet.new(values.message_set.to_a, failures: true)
       end
 
       # Check if result is successful
@@ -63,7 +49,7 @@ module Dry
       #
       # @api public
       def success?
-        error_set.empty?
+        errors.empty?
       end
 
       # Check if result is not successful
@@ -86,7 +72,7 @@ module Dry
       #
       # @api private
       def add_error(error)
-        error_set.add(error)
+        errors.add(error)
         self
       end
 
@@ -142,14 +128,14 @@ module Dry
       #
       # @api public
       def inspect
-        "#<#{self.class}#{to_h.inspect} errors=#{errors.inspect}>"
+        "#<#{self.class}#{to_h.inspect} errors=#{errors.to_h.inspect}>"
       end
 
       # Freeze result and its error set
       #
       # @api private
       def freeze
-        error_set.freeze
+        errors.freeze
         super
       end
 

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Dry::Validation::Result do
         monad = result.to_monad
 
         expect(monad).to be_a_failure
-        expect(monad.failure.messages).to eql(name: ['must be filled', 'length must be within 2 - 4'])
+        expect(monad.failure.messages.to_h).to eql(name: ['must be filled', 'length must be within 2 - 4'])
       end
     end
   end

--- a/spec/integration/contract/call_spec.rb
+++ b/spec/integration/contract/call_spec.rb
@@ -42,34 +42,34 @@ RSpec.describe Dry::Validation::Contract, '#call' do
     result = contract.(email: 'john@doe.org', age: 19)
 
     expect(result).to be_success
-    expect(result.errors).to eql({})
+    expect(result.errors.to_h).to eql({})
   end
 
   it 'returns rule errors' do
     result = contract.(email: 'john@doe.org', login: 'jane', age: 19)
 
     expect(result).to be_failure
-    expect(result.errors).to eql(password: ['is required'])
+    expect(result.errors.to_h).to eql(password: ['is required'])
   end
 
   it "doesn't execute rules when basic checks failed" do
     result = contract.(email: 'john@doe.org', age: 'not-an-integer')
 
     expect(result).to be_failure
-    expect(result.errors).to eql(age: ['must be an integer'])
+    expect(result.errors.to_h).to eql(age: ['must be an integer'])
   end
 
   it 'gathers errors from multiple rules for the same key' do
     result = contract.(email: 'john@doe.org', age: -1)
 
     expect(result).to be_failure
-    expect(result.errors).to eql(age: ['must be greater or equal 18', 'must be greater than 0'])
+    expect(result.errors.to_h).to eql(age: ['must be greater or equal 18', 'must be greater than 0'])
   end
 
   it 'build nested message keys for nested rules' do
     result = contract.(email: 'john@doe.org', age: 20, address: { country: 'Russia', zip: 'abc' })
 
     expect(result).to be_failure
-    expect(result.errors).to eql(address: { zip: ['must have 6 digit'] })
+    expect(result.errors.to_h).to eql(address: { zip: ['must have 6 digit'] })
   end
 end

--- a/spec/integration/contract/class_interface/rule_spec.rb
+++ b/spec/integration/contract/class_interface/rule_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
     end
 
     it 'applies rule when value passed schema checks' do
-      expect(contract.(email: 'jane@doe.org', login: 'ab').errors).to eql(login: ['is too short'])
+      expect(contract.(email: 'jane@doe.org', login: 'ab').errors.to_h).to eql(login: ['is too short'])
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
     end
 
     it 'applies the rule regardless of the schema result' do
-      expect(contract.(email: 'jane@doe.org', login: 'jane').errors).to eql(custom: ['this works'])
+      expect(contract.(email: 'jane@doe.org', login: 'jane').errors.to_h).to eql(custom: ['this works'])
     end
   end
 
@@ -50,10 +50,10 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
     end
 
     it 'applies the rule when nested value passed schema checks' do
-      expect(contract.(email: 'jane@doe.org', login: 'jane', address: nil).errors)
+      expect(contract.(email: 'jane@doe.org', login: 'jane', address: nil).errors.to_h)
         .to eql(address: ['must be a hash'])
 
-      expect(contract.(email: 'jane@doe.org', login: 'jane', address: { street: ' ' }).errors)
+      expect(contract.(email: 'jane@doe.org', login: 'jane', address: { street: ' ' }).errors.to_h)
         .to eql(address: { street: ['cannot be empty'] })
     end
   end
@@ -78,7 +78,7 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
     end
 
     it 'applies the rule when nested value passed schema checks' do
-      expect(contract.(email: 'jane@doe.org', login: 'jane', address: { street: ' ' }).errors)
+      expect(contract.(email: 'jane@doe.org', login: 'jane', address: { street: ' ' }).errors.to_h)
         .to eql(
           address: [
             ['invalid no matter what', 'seriously invalid'],
@@ -96,10 +96,10 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
     end
 
     it 'sets a base error not attached to any key' do
-      expect(contract.(email: 'jane@doe.org', login: '').errors)
-        .to eql(login: ['must be filled'])
+      expect(contract.(email: 'jane@doe.org', login: '').errors.to_h)
+        .to eql(login: ['must be filled'], nil => ['this whole thing is invalid'])
 
-      expect(contract.(email: 'jane@doe.org', login: '').base_errors)
+      expect(contract.(email: 'jane@doe.org', login: '').errors.filter(:base?).map(&:to_s))
         .to eql(['this whole thing is invalid'])
     end
   end
@@ -114,10 +114,10 @@ RSpec.describe Dry::Validation::Contract, '.rule' do
     end
 
     it 'applies the rule when all values passed schema checks' do
-      expect(contract.(email: nil, login: nil).errors)
+      expect(contract.(email: nil, login: nil).errors.to_h)
         .to eql(email: ['must be a string'], login: ['must be a string'])
 
-      expect(contract.(email: 'jane@doe.org', login: 'jane').errors)
+      expect(contract.(email: 'jane@doe.org', login: 'jane').errors.to_h)
         .to eql(login: ['is not needed when email is provided'])
     end
   end

--- a/spec/integration/contract/evaluator/setting_values_spec.rb
+++ b/spec/integration/contract/evaluator/setting_values_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Dry::Validation::Evaluator, 'values writer' do
     end
 
     it 'stores new values between rule execution' do
-      expect(contract.(user_id: 3, email: 'john@doe.org').errors).to eql(user: ['must be jane'])
-      expect(contract.(user_id: 312, email: 'john@doe.org').errors).to eql(email: ['is invalid'])
+      expect(contract.(user_id: 3, email: 'john@doe.org').errors.to_h).to eql(user: ['must be jane'])
+      expect(contract.(user_id: 312, email: 'john@doe.org').errors.to_h).to eql(email: ['is invalid'])
     end
   end
 

--- a/spec/integration/contract/external_deps_spec.rb
+++ b/spec/integration/contract/external_deps_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe Dry::Validation::Contract, '.option' do
 
     contract = contract_class.new(db: db)
 
-    expect(contract.(email: 'jane@doe.org').errors).to eql(email: ['is taken'])
+    expect(contract.(email: 'jane@doe.org').errors.to_h).to eql(email: ['is taken'])
   end
 end

--- a/spec/integration/contract/using_messages_spec.rb
+++ b/spec/integration/contract/using_messages_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe Dry::Validation::Contract do
 
     describe 'failure' do
       it 'uses messages for failures' do
-        expect(contract.(email: 'foo').errors)
+        expect(contract.(email: 'foo').errors.to_h)
           .to eql(email: ['oh noez bad email'])
       end
 
       it 'passes tokens to message templates' do
-        expect(contract.(email: 'jane@doe.org').errors)
+        expect(contract.(email: 'jane@doe.org').errors.to_h)
           .to eql(email: ['looks like jane@doe.org is taken'])
       end
     end

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -26,4 +26,29 @@ RSpec.describe Dry::Validation::Result do
       end
     end
   end
+
+  describe '#errors' do
+    subject(:errors) { result.errors }
+
+    let(:params) do
+      double(:params, message_set: [], to_h: { email: 'jane@doe.org' })
+    end
+
+    let(:result) do
+      Dry::Validation::Result.new(params) do |r|
+        r.add_error(Dry::Validation::Error.new('root error', path: nil))
+        r.add_error(Dry::Validation::Error.new('email error', path: :email))
+      end
+    end
+
+    describe '#[]' do
+      it 'returns error messages for the provided key' do
+        expect(errors[:email]).to eql(['email error'])
+      end
+
+      it 'returns [] for base errors' do
+        expect(errors[nil]).to eql(['root error'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a significant change and improvement - `Result#errors` returns now an instance of `ErrorSet`, this object holds both message objects from dry-schema and validation error objects, too. It quacks like a hash, so `#[]` and `#each` + rest of enum works.

It **is a breaking change** because `#errors` is no longer a hash.

The main motivation behind this change is dealing with "base" errors because they have no keys associated with them. It was weird to deal with them separately from other errors as `Result#errors` didn't include them, which could be surprising or even lead to bugs.

Another reason is that it reduces `Result` API, which is always a good thing and it puts more emphasis on the richer `ErrorSet` object.