### PR TITLE
Error options

### DIFF
--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -112,7 +112,7 @@ module Dry
       #
       # @api public
       def call(input)
-        Result.new(schema.(input)) do |result|
+        Result.new(schema.(input), locale: locale) do |result|
           rules.each do |rule|
             next if rule.keys.any? { |key| result.error?(key) }
 

--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -110,19 +110,9 @@ module Dry
             next if rule.keys.any? { |key| result.error?(key) }
 
             rule_result = rule.(self, result)
-            result.add_error(rule_result.message) if rule_result.failure?
+            result.add_error(message_resolver[rule_result.message]) if rule_result.failure?
           end
         end
-      end
-
-      # Get message text for the given rule name and options
-      #
-      # @return [String]
-      #
-      # @api private
-      def message(key, rule: key, tokens: EMPTY_HASH, **opts)
-        path = Array(opts.fetch(:path)).flatten.compact
-        Error.new(message_resolver[key, tokens: tokens, path: path], rule: rule, path: path)
       end
     end
   end

--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -84,6 +84,11 @@ module Dry
 
       # @!endgroup
 
+      # @!attribute [r] locale
+      #   @return [Symbol]
+      #   @api public
+      option :locale, default: -> { :en }
+
       # @!attribute [r] schema
       #   @return [Dry::Schema::Params, Dry::Schema::JSON, Dry::Schema::Processor]
       #   @api private
@@ -97,7 +102,9 @@ module Dry
       # @!attribute [r] message_resolver
       #   @return [Messages::Resolver]
       #   @api private
-      option :message_resolver, default: -> { Messages::Resolver.new(self.class.messages) }
+      option :message_resolver, default: proc {
+        Messages::Resolver.new(self.class.messages, locale)
+      }
 
       # Apply contract to an input
       #

--- a/lib/dry/validation/error.rb
+++ b/lib/dry/validation/error.rb
@@ -19,6 +19,23 @@ module Dry
       #   @return [Array<Symbol, Integer>] path The path to the value with the error
       attr_reader :path
 
+      # @api public
+      class Localized < Error
+        # @api public
+        def evaluate(locale)
+          Error.new(text.(locale), path: path)
+        end
+      end
+
+      # Build an error
+      #
+      # @return [Error, Error::Localized]
+      #
+      # @api public
+      def self.[](text, path)
+        text.respond_to?(:call) ? Localized.new(text, path: path) : Error.new(text, path: path)
+      end
+
       # Initialize a new error object
       #
       # @api private

--- a/lib/dry/validation/error.rb
+++ b/lib/dry/validation/error.rb
@@ -22,8 +22,8 @@ module Dry
       # @api public
       class Localized < Error
         # @api public
-        def evaluate(locale)
-          Error.new(text.(locale), path: path)
+        def evaluate(**opts)
+          Error.new(text.(opts), path: path)
         end
       end
 

--- a/lib/dry/validation/error.rb
+++ b/lib/dry/validation/error.rb
@@ -15,10 +15,6 @@ module Dry
       #   @return [String] text The error message text
       attr_reader :text
 
-      # @!attribute [r] rule
-      #   @return [Symbol] rule The rule identifier (might be the same as path)
-      attr_reader :rule
-
       # @!attribute [r] path
       #   @return [Array<Symbol, Integer>] path The path to the value with the error
       attr_reader :path
@@ -26,11 +22,9 @@ module Dry
       # Initialize a new error object
       #
       # @api private
-      def initialize(text, path:, rule: nil)
+      def initialize(text, path:)
         @text = text
-        @path = build_path(path, [])
-        @rule = rule || @path.last
-        @base = path.nil?
+        @path = Array(path)
       end
 
       # Check if this is a base error not associated with any key
@@ -39,7 +33,7 @@ module Dry
       #
       # @api public
       def base?
-        @base
+        @base ||= path.compact.empty?
       end
 
       # Dump error to a string
@@ -49,21 +43,6 @@ module Dry
       # @api public
       def to_s
         text
-      end
-
-      private
-
-      # @api private
-      def build_path(path, acc)
-        case path
-        when Hash
-          key, value = path.first
-          build_path(value, acc << key)
-        when Array
-          acc.concat(path)
-        else
-          acc << path
-        end
       end
     end
   end

--- a/lib/dry/validation/error_set.rb
+++ b/lib/dry/validation/error_set.rb
@@ -11,6 +11,17 @@ module Dry
     #
     # @api public
     class ErrorSet < Schema::MessageSet
+      # @!attribute [r] locale
+      #   @return [Symbol] locale
+      #   @api public
+      attr_reader :locale
+
+      # @api private
+      def initialize(messages, options = EMPTY_HASH)
+        super
+        @locale = options.fetch(:locale, :en)
+      end
+
       # Add a new error
       #
       # This is used when result is being prepared
@@ -48,6 +59,9 @@ module Dry
 
       # @api private
       def freeze
+        select { |err| err.respond_to?(:evaluate) }.each do |err|
+          messages[messages.index(err)] = err.evaluate(locale)
+        end
         to_h
         self
       end

--- a/lib/dry/validation/error_set.rb
+++ b/lib/dry/validation/error_set.rb
@@ -11,6 +11,12 @@ module Dry
     #
     # @api public
     class ErrorSet < Schema::MessageSet
+      # @!attribute [r] source
+      #   Return the source set of messages used to produce final evaluated messages
+      #   @return [Array<Error, Error::Localized, Schema::Message>]
+      #   @api private
+      attr_reader :source_messages
+
       # @!attribute [r] locale
       #   @return [Symbol] locale
       #   @api public
@@ -18,8 +24,23 @@ module Dry
 
       # @api private
       def initialize(messages, options = EMPTY_HASH)
-        super
         @locale = options.fetch(:locale, :en)
+        @source_messages = options.fetch(:source, messages.dup)
+        super
+      end
+
+      # Return a new error set using updated options
+      #
+      # @return [ErrorSet]
+      #
+      # @api private
+      def with(other, new_options = EMPTY_HASH)
+        return self if new_options.empty?
+
+        self.class.new(
+          other + select { |err| err.is_a?(Error) },
+          options.merge(source: source_messages, **new_options)
+        ).freeze
       end
 
       # Add a new error
@@ -30,6 +51,7 @@ module Dry
       #
       # @api private
       def add(error)
+        source_messages << error
         messages << error
         initialize_placeholders!
         self
@@ -59,8 +81,10 @@ module Dry
 
       # @api private
       def freeze
-        select { |err| err.respond_to?(:evaluate) }.each do |err|
-          messages[messages.index(err)] = err.evaluate(locale)
+        source_messages.select { |err| err.respond_to?(:evaluate) }.each do |err|
+          idx = source_messages.index(err)
+          msg = err.evaluate(locale: locale, full: options[:full])
+          messages[idx] = msg
         end
         to_h
         self
@@ -70,7 +94,7 @@ module Dry
 
       # @api private
       def unique_paths
-        uniq(&:path).map(&:path)
+        source_messages.uniq(&:path).map(&:path)
       end
 
       # @api private

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -25,10 +25,10 @@ module Dry
       #   @api private
       option :keys
 
-      # @!attribute [r] default_id
-      #   @return [String, Symbol, Hash]
+      # @!attribute [r] path
+      #   @return [Dry::Schema::Path]
       #   @api private
-      option :default_id, default: proc { keys.first }
+      option :path, default: proc { Dry::Schema::Path[(key = keys.first) ? key : [nil]] }
 
       # @!attribute [r] values
       #   @return [Object]
@@ -73,21 +73,8 @@ module Dry
       #
       # @api public
       def failure(*args, **tokens)
-        error =
-          if args.size.equal?(1)
-            case (msg = args[0])
-            when Symbol
-              _context.message(msg, path: default_id, tokens: tokens)
-            when String
-              Error.new(msg, path: default_id)
-            end
-          else
-            Error.new(args[1], path: args[0])
-          end
-
         @failure = true
-        @message = error
-
+        @message = { args: args, tokens: tokens, path: path }
         self
       end
 

--- a/lib/dry/validation/messages.rb
+++ b/lib/dry/validation/messages.rb
@@ -1,26 +1,12 @@
 # frozen_string_literal: true
 
 require 'dry/schema/messages'
+require 'dry/validation/messages/yaml'
+require 'dry/validation/messages/i18n' if defined?(I18n)
 
 module Dry
   module Validation
     module Messages
-      class YAML < Schema::Messages::YAML
-        config.root = config.root.gsub('dry_schema', 'dry_validation')
-        config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
-          path.gsub('dry_schema', 'dry_validation')
-        }
-      end
-
-      if defined?(::I18n)
-        class I18n < Schema::Messages::I18n
-          config.root = config.root.gsub('dry_schema', 'dry_validation')
-          config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
-            path.gsub('dry_schema', 'dry_validation')
-          }
-        end
-      end
-
       # @api private
       def self.setup(config)
         messages = build(config)

--- a/lib/dry/validation/messages/i18n.rb
+++ b/lib/dry/validation/messages/i18n.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dry
+  module Validation
+    module Messages
+      class I18n < Schema::Messages::I18n
+        config.root = config.root.gsub('dry_schema', 'dry_validation')
+        config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
+          path.gsub('dry_schema', 'dry_validation')
+        }
+      end
+    end
+  end
+end

--- a/lib/dry/validation/messages/resolver.rb
+++ b/lib/dry/validation/messages/resolver.rb
@@ -34,8 +34,8 @@ module Dry
           if args.size.equal?(1)
             case (msg = args[0])
             when Symbol
-              text = lambda { |locale|
-                message(msg, path: path, tokens: tokens, locale: locale)
+              text = lambda { |**opts|
+                message(msg, path: path, tokens: tokens, **opts)
               }
 
               Error[text, path]
@@ -53,7 +53,7 @@ module Dry
         # @return [String]
         #
         # @api public
-        def message(rule, tokens: EMPTY_HASH, path:, locale: self.locale)
+        def message(rule, tokens: EMPTY_HASH, path:, locale: self.locale, full: false)
           keys = path.to_a.compact
           msg_opts = tokens.merge(path: keys, locale: locale)
 
@@ -70,7 +70,9 @@ module Dry
             STR
           end
 
-          template.(template.data(tokens))
+          text = template.(template.data(tokens))
+
+          full ? "#{messages.rule(keys.last, msg_opts)} #{text}" : text
         end
       end
     end

--- a/lib/dry/validation/messages/resolver.rb
+++ b/lib/dry/validation/messages/resolver.rb
@@ -12,9 +12,15 @@ module Dry
         #   @api private
         attr_reader :messages
 
+        # @!attribute [r] locale
+        #   @return [Symbol] current locale
+        #   @api private
+        attr_reader :locale
+
         # @api private
-        def initialize(messages)
+        def initialize(messages, locale = :en)
           @messages = messages
+          @locale = locale
         end
 
         # Resolve Error object from provided args and path
@@ -48,10 +54,10 @@ module Dry
         # @api public
         def message(rule, tokens: EMPTY_HASH, path:)
           keys = path.to_a.compact
-          msg_opts = tokens.merge(path: keys)
+          msg_opts = tokens.merge(path: keys, locale: locale)
 
           if keys.empty?
-            template = messages["rules.#{rule}", path: keys]
+            template = messages["rules.#{rule}", msg_opts]
           else
             template = messages[rule, msg_opts.merge(path: keys.join(DOT))]
             template ||= messages[rule, msg_opts.merge(path: keys.last)]

--- a/lib/dry/validation/messages/resolver.rb
+++ b/lib/dry/validation/messages/resolver.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Dry
+  module Validation
+    module Messages
+      # Resolve translated messages from failure arguments
+      #
+      # @api public
+      class Resolver
+        # @!attribute [r] messages
+        #   @return [Messages::I18n, Messages::YAML] messages backend
+        #   @api private
+        attr_reader :messages
+
+        # @api private
+        def initialize(messages)
+          @messages = messages
+        end
+
+        # Resolve a message
+        #
+        # @return [String]
+        #
+        # @api public
+        def call(key, tokens: EMPTY_HASH, path:)
+          msg_opts = tokens.merge(path: path)
+
+          if path.empty?
+            template = messages["rules.#{key}", path: path]
+          else
+            template = messages[key, msg_opts.merge(path: path.join(DOT))]
+            template ||= messages[key, msg_opts.merge(path: path.last)]
+          end
+
+          unless template
+            raise MissingMessageError, <<~STR
+              Message template for #{key.inspect} under #{path.join(DOT).inspect} was not found
+            STR
+          end
+
+          template.(template.data(tokens))
+        end
+        alias_method :[], :call
+      end
+    end
+  end
+end

--- a/lib/dry/validation/messages/resolver.rb
+++ b/lib/dry/validation/messages/resolver.rb
@@ -31,19 +31,20 @@ module Dry
         #
         # @api public
         def call(args:, tokens:, path:)
-          text, path =
-            if args.size.equal?(1)
-              case (msg = args[0])
-              when Symbol
-                [message(msg, path: path, tokens: tokens), path]
-              when String
-                [msg, path]
-              end
-            else
-              args.reverse
-            end
+          if args.size.equal?(1)
+            case (msg = args[0])
+            when Symbol
+              text = lambda { |locale|
+                message(msg, path: path, tokens: tokens, locale: locale)
+              }
 
-          Error.new(text, path: path)
+              Error[text, path]
+            when String
+              Error[msg, path]
+            end
+          else
+            Error[*args.reverse]
+          end
         end
         alias_method :[], :call
 
@@ -52,7 +53,7 @@ module Dry
         # @return [String]
         #
         # @api public
-        def message(rule, tokens: EMPTY_HASH, path:)
+        def message(rule, tokens: EMPTY_HASH, path:, locale: self.locale)
           keys = path.to_a.compact
           msg_opts = tokens.merge(path: keys, locale: locale)
 

--- a/lib/dry/validation/messages/yaml.rb
+++ b/lib/dry/validation/messages/yaml.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Dry
+  module Validation
+    module Messages
+      class YAML < Schema::Messages::YAML
+        config.root = config.root.gsub('dry_schema', 'dry_validation')
+        config.rule_lookup_paths = config.rule_lookup_paths.map { |path|
+          path.gsub('dry_schema', 'dry_validation')
+        }
+      end
+    end
+  end
+end

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -48,8 +48,8 @@ module Dry
       # @return [ErrorSet]
       #
       # @api public
-      def errors(options = EMPTY_HASH)
-        options.empty? ? @errors : initialize_errors(options)
+      def errors(new_options = EMPTY_HASH)
+        new_options.empty? ? @errors : @errors.with(schema_errors(new_options), new_options)
       end
       alias_method :messages, :errors
 
@@ -153,9 +153,12 @@ module Dry
 
       # @api private
       def initialize_errors(options = self.options)
-        result_errors = defined?(@errors) ? @errors.to_a : EMPTY_ARRAY
-        schema_errors = values.message_set(options).to_a
-        ErrorSet.new(schema_errors + result_errors, options)
+        ErrorSet.new(schema_errors(options), options)
+      end
+
+      # @api private
+      def schema_errors(options)
+        values.message_set(options).to_a
       end
 
       # @api private

--- a/spec/fixtures/messages/errors.en.yml
+++ b/spec/fixtures/messages/errors.en.yml
@@ -1,5 +1,10 @@
 en:
+  dry_schema:
+    rules:
+      email: "E-mail"
   dry_validation:
+    rules:
+      email: "E-mail"
     errors:
       rules:
         not_weekend: "this only works on weekends"

--- a/spec/fixtures/messages/errors.pl.yml
+++ b/spec/fixtures/messages/errors.pl.yml
@@ -1,0 +1,13 @@
+pl:
+  dry_validation:
+    errors:
+      rules:
+        not_weekend: "to działa tylko w weekendy"
+        email:
+          invalid: "oh nie zły email"
+          taken: "wygląda, że %{email} jest zajęty"
+        city:
+          invalid: "nie jest poprawną nazwą miasta"
+        address:
+          street:
+            invalid: "nie wygląda dobrze"

--- a/spec/integration/contract/using_messages_spec.rb
+++ b/spec/integration/contract/using_messages_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Dry::Validation::Contract do
       expect(contract.schema.config.messages_file).to eql(contract.class.config.messages_file)
     end
 
+    describe 'result errors' do
+      it 'supports full: true option for schema errors' do
+        expect(contract.(email: '').errors(full: true).map(&:to_s))
+          .to eql(['E-mail must be filled'])
+      end
+
+      it 'supports full: true option for contract errors' do
+        expect(contract.(email: 'jane').errors(full: true).map(&:to_s))
+          .to eql(['E-mail oh noez bad email'])
+      end
+    end
+
     describe 'failure' do
       it 'uses messages for failures' do
         expect(contract.(email: 'foo').errors.to_h)

--- a/spec/integration/evaluator_spec.rb
+++ b/spec/integration/evaluator_spec.rb
@@ -19,17 +19,6 @@ RSpec.describe Dry::Validation::Evaluator do
     {}
   end
 
-  describe '#failure' do
-    let(:block) do
-      proc { failure('oops') }
-    end
-
-    it 'sets a failure message' do
-      expect(evaluator.message.rule).to eql(:email)
-      expect(evaluator.message.text).to eql('oops')
-    end
-  end
-
   describe '#failure?' do
     context 'when failure message was set' do
       let(:block) do
@@ -61,8 +50,8 @@ RSpec.describe Dry::Validation::Evaluator do
 
     it 'delegates to the context' do
       expect(context).to receive(:works?).and_return(true)
-      expect(evaluator.message.rule).to eql(:email)
-      expect(evaluator.message.text).to eql('it works')
+      expect(evaluator.message[:path].to_a).to eql([:email])
+      expect(evaluator.message[:args]).to eql(['it works'])
     end
 
     describe 'with custom methods defined on the context' do
@@ -75,8 +64,7 @@ RSpec.describe Dry::Validation::Evaluator do
       end
 
       it 'forwards to the context' do
-        expect(evaluator.message.rule).to eql(:email)
-        expect(evaluator.message.text).to eql('message with my_context')
+        expect(evaluator.message[:args]).to eql(['message with my_context'])
       end
     end
   end

--- a/spec/integration/messages/resolver_spec.rb
+++ b/spec/integration/messages/resolver_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe Dry::Validation::Contract, '#message' do
+RSpec.describe Dry::Validation::Messages::Resolver, '#message' do
   shared_context 'resolving' do
-    subject(:contract) do
-      contract_class.new
+    subject(:resolver) do
+      contract_class.new.message_resolver
     end
 
     let(:contract_class) do
@@ -13,27 +13,23 @@ RSpec.describe Dry::Validation::Contract, '#message' do
     end
 
     it 'returns message text for base rule' do
-      expect(contract.message(:not_weekend, path: nil).to_s)
-        .to eql('this only works on weekends')
+      expect(resolver.message(:not_weekend, path: [nil]).to_s).to eql('this only works on weekends')
     end
 
     it 'returns message text for flat rule' do
-      expect(contract.message(:taken, path: :email, tokens: { email: 'jane@doe.org' }).to_s)
-        .to eql('looks like jane@doe.org is taken')
+      expect(resolver.message(:taken, path: [:email], tokens: { email: 'jane@doe.org' }).to_s).to eql('looks like jane@doe.org is taken')
     end
 
     it 'returns message text for nested rule when it is defined under root' do
-      expect(contract.message(:invalid, path: %i[address city]).to_s)
-        .to eql('is not a valid city name')
+      expect(resolver.message(:invalid, path: %i[address city]).to_s).to eql('is not a valid city name')
     end
 
     it 'returns message text for nested rule' do
-      expect(contract.message(:invalid, path: %i[address street]).to_s)
-        .to eql("doesn't look good")
+      expect(resolver.message(:invalid, path: %i[address street]).to_s).to eql("doesn't look good")
     end
 
     it 'raises error when template was not found' do
-      expect { contract.message(:not_here, path: :email) }
+      expect { resolver.message(:not_here, path: [:email]) }
         .to raise_error(Dry::Validation::MissingMessageError, <<~STR)
           Message template for :not_here under "email" was not found
         STR

--- a/spec/integration/messages/resolver_spec.rb
+++ b/spec/integration/messages/resolver_spec.rb
@@ -3,36 +3,75 @@
 RSpec.describe Dry::Validation::Messages::Resolver, '#message' do
   shared_context 'resolving' do
     subject(:resolver) do
-      contract_class.new.message_resolver
+      contract_class.new(locale: locale).message_resolver
     end
 
     let(:contract_class) do
-      Class.new(Dry::Validation::Contract) do
-        config.messages_file = SPEC_ROOT.join('fixtures/messages/errors.en.yml').realpath
+      Class.new(Dry::Validation::Contract)
+    end
+
+    before do
+      contract_class.config.messages_file = SPEC_ROOT
+        .join("fixtures/messages/errors.#{locale}.yml").realpath
+
+      I18n.available_locales << :pl
+      I18n.backend.load_translations
+      I18n.reload!
+    end
+
+    context ':en' do
+      let(:locale) { :en }
+
+      it 'returns message text for base rule' do
+        expect(resolver.message(:not_weekend, path: [nil]).to_s)
+          .to eql('this only works on weekends')
+      end
+
+      it 'returns message text for flat rule' do
+        expect(resolver.message(:taken, path: [:email], tokens: { email: 'jane@doe.org' }).to_s)
+          .to eql('looks like jane@doe.org is taken')
+      end
+
+      it 'returns message text for nested rule when it is defined under root' do
+        expect(resolver.message(:invalid, path: %i[address city]).to_s)
+          .to eql('is not a valid city name')
+      end
+
+      it 'returns message text for nested rule' do
+        expect(resolver.message(:invalid, path: %i[address street]).to_s)
+          .to eql("doesn't look good")
+      end
+
+      it 'raises error when template was not found' do
+        expect { resolver.message(:not_here, path: [:email]) }
+          .to raise_error(Dry::Validation::MissingMessageError, <<~STR)
+            Message template for :not_here under "email" was not found
+          STR
       end
     end
 
-    it 'returns message text for base rule' do
-      expect(resolver.message(:not_weekend, path: [nil]).to_s).to eql('this only works on weekends')
-    end
+    context ':pl' do
+      let(:locale) { :pl }
 
-    it 'returns message text for flat rule' do
-      expect(resolver.message(:taken, path: [:email], tokens: { email: 'jane@doe.org' }).to_s).to eql('looks like jane@doe.org is taken')
-    end
+      it 'returns message text for base rule' do
+        expect(resolver.message(:not_weekend, path: [nil]).to_s)
+          .to eql('to działa tylko w weekendy')
+      end
 
-    it 'returns message text for nested rule when it is defined under root' do
-      expect(resolver.message(:invalid, path: %i[address city]).to_s).to eql('is not a valid city name')
-    end
+      it 'returns message text for flat rule' do
+        expect(resolver.message(:taken, path: [:email], tokens: { email: 'jane@doe.org' }).to_s)
+          .to eql('wygląda, że jane@doe.org jest zajęty')
+      end
 
-    it 'returns message text for nested rule' do
-      expect(resolver.message(:invalid, path: %i[address street]).to_s).to eql("doesn't look good")
-    end
+      it 'returns message text for nested rule when it is defined under root' do
+        expect(resolver.message(:invalid, path: %i[address city]).to_s)
+          .to eql('nie jest poprawną nazwą miasta')
+      end
 
-    it 'raises error when template was not found' do
-      expect { resolver.message(:not_here, path: [:email]) }
-        .to raise_error(Dry::Validation::MissingMessageError, <<~STR)
-          Message template for :not_here under "email" was not found
-        STR
+      it 'returns message text for nested rule' do
+        expect(resolver.message(:invalid, path: %i[address street]).to_s)
+          .to eql('nie wygląda dobrze')
+      end
     end
   end
 

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Dry::Validation::Result do
 
     let(:result) do
       Dry::Validation::Result.new(params) do |r|
-        r.add_error(Dry::Validation::Error.new('root error', path: nil))
-        r.add_error(Dry::Validation::Error.new('email error', path: :email))
+        r.add_error(Dry::Validation::Error.new('root error', path: [nil]))
+        r.add_error(Dry::Validation::Error.new('email error', path: [:email]))
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,5 +44,9 @@ RSpec.configure do |config|
 
   config.after do
     Object.send(:remove_const, Test.remove_constants.name)
+
+    I18n.load_path = Dry::Schema.messages_paths.dup
+    I18n.locale = :en
+    I18n.reload!
   end
 end


### PR DESCRIPTION
This restores support for passing options to `Result#errors`:

``` ruby
require 'dry/validation/contract'

class NewUserContract < Dry::Validation::Contract
  params do
    required(:email).filled(:string)
  end
end

contract = NewUserContract.new

puts contract.(email: '').errors.inspect
# {:email=>["must be filled"]}

puts contract.(email: '').errors(locale: :pl).inspect
# {:email=>["musi być wypełniony"]}

puts contract.(email: '').errors(full: true).map(&:to_s)
# ["E-mail must be filled"]
```

Closes #479 
Closes #480 