### PR TITLE
Remove Result#to_hash

### DIFF
--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -48,7 +48,7 @@ module Dry
         #     failure(:taken)
         #
         # @api public
-        def failure(message, **tokens)
+        def failure(message, tokens = EMPTY_HASH)
           @opts << { message: message, tokens: tokens, path: path }
           self
         end

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -132,7 +132,6 @@ module Dry
       def to_h
         values.to_h
       end
-      alias_method :to_hash, :to_h
 
       # Return a string representation
       #

--- a/spec/integration/contract/using_messages_spec.rb
+++ b/spec/integration/contract/using_messages_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dry::Validation::Contract do
         rule(:email) do
           value = values[:email]
           key.failure(:invalid) unless value.include?('@')
-          key.failure(:taken, values) if value == 'jane@doe.org'
+          key.failure(:taken, values.to_h) if value == 'jane@doe.org'
         end
       end
     end


### PR DESCRIPTION
Having it defined in classes that are not completely Hash-like is a common source of problems due to implicit conversions made by ruby when passing keywords around. Current ruby behavior may change in the future but for now it seems it's better not to define `to_hash` without clear benefits.