### PR TITLE
Allow passing text + meta to failure

### DIFF
--- a/spec/integration/contract/evaluator/failure_spec.rb
+++ b/spec/integration/contract/evaluator/failure_spec.rb
@@ -77,4 +77,19 @@ RSpec.describe Dry::Validation::Evaluator do
       expect(contract.(email: 'foo').errors.to_h).to eql(nil => ['is invalid'])
     end
   end
+
+  context 'setting failures with meta data' do
+    before do
+      contract_class.rule(:email) do
+        key.failure(text: 'is invalid', code: 102)
+      end
+    end
+
+    it 'sets error under specified key' do
+      errors = contract.(email: 'foo').errors
+
+      expect(errors.to_h).to eql(email: ['is invalid'])
+      expect(errors.first.meta).to eql(code: 102)
+    end
+  end
 end

--- a/spec/integration/messages/resolver_spec.rb
+++ b/spec/integration/messages/resolver_spec.rb
@@ -21,23 +21,23 @@ RSpec.describe Dry::Validation::Messages::Resolver, '#message' do
       let(:locale) { :en }
 
       it 'returns message text for base rule' do
-        expect(resolver.message(:not_weekend, path: [nil]).to_s)
-          .to eql('this only works on weekends')
+        expect(resolver.message(:not_weekend, path: [nil]))
+          .to eql(['this only works on weekends', {}])
       end
 
       it 'returns message text for flat rule' do
-        expect(resolver.message(:taken, path: [:email], tokens: { email: 'jane@doe.org' }).to_s)
-          .to eql('looks like jane@doe.org is taken')
+        expect(resolver.message(:taken, path: [:email], tokens: { email: 'jane@doe.org' }))
+          .to eql(['looks like jane@doe.org is taken', {}])
       end
 
       it 'returns message text for nested rule when it is defined under root' do
-        expect(resolver.message(:invalid, path: %i[address city]).to_s)
-          .to eql('is not a valid city name')
+        expect(resolver.message(:invalid, path: %i[address city]))
+          .to eql(['is not a valid city name', {}])
       end
 
       it 'returns message text for nested rule' do
-        expect(resolver.message(:invalid, path: %i[address street]).to_s)
-          .to eql("doesn't look good")
+        expect(resolver.message(:invalid, path: %i[address street]))
+          .to eql(["doesn't look good", {}])
       end
 
       it 'raises error when template was not found' do
@@ -52,23 +52,23 @@ RSpec.describe Dry::Validation::Messages::Resolver, '#message' do
       let(:locale) { :pl }
 
       it 'returns message text for base rule' do
-        expect(resolver.message(:not_weekend, path: [nil]).to_s)
-          .to eql('to działa tylko w weekendy')
+        expect(resolver.message(:not_weekend, path: [nil]))
+          .to eql(['to działa tylko w weekendy', {}])
       end
 
       it 'returns message text for flat rule' do
-        expect(resolver.message(:taken, path: [:email], tokens: { email: 'jane@doe.org' }).to_s)
-          .to eql('wygląda, że jane@doe.org jest zajęty')
+        expect(resolver.message(:taken, path: [:email], tokens: { email: 'jane@doe.org' }))
+          .to eql(['wygląda, że jane@doe.org jest zajęty', {}])
       end
 
       it 'returns message text for nested rule when it is defined under root' do
-        expect(resolver.message(:invalid, path: %i[address city]).to_s)
-          .to eql('nie jest poprawną nazwą miasta')
+        expect(resolver.message(:invalid, path: %i[address city]))
+          .to eql(['nie jest poprawną nazwą miasta', {}])
       end
 
       it 'returns message text for nested rule' do
-        expect(resolver.message(:invalid, path: %i[address street]).to_s)
-          .to eql('nie wygląda dobrze')
+        expect(resolver.message(:invalid, path: %i[address street]))
+          .to eql(['nie wygląda dobrze', {}])
       end
     end
   end


### PR DESCRIPTION
This adds support for passing not just the text of a message, but also any arbitrary meta-data you may need.

Refs dry-rb/dry-schema#39