### PR TITLE
Wrap whole validation result with result monad

### DIFF
--- a/lib/dry/validation/extensions/monads.rb
+++ b/lib/dry/validation/extensions/monads.rb
@@ -27,7 +27,7 @@ module Dry
       #
       # @api public
       def to_monad
-        success? ? Success(to_h) : Failure(self)
+        success? ? Success(self) : Failure(self)
       end
     end
   end

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Dry::Validation::Result do
 
         expect(monad).to be_a Dry::Monads::Result
         expect(monad).to be_a_success
-        expect(monad.value!).to eql(name: 'Jane')
+        expect(monad.value!).to be(result)
       end
     end
   end
@@ -35,7 +35,7 @@ RSpec.describe Dry::Validation::Result do
         monad = result.to_monad
 
         expect(monad).to be_a_failure
-        expect(monad.failure.messages.to_h).to eql(name: ['must be filled', 'length must be within 2 - 4'])
+        expect(monad.failure).to eql(result)
       end
     end
   end


### PR DESCRIPTION
Result objects from dry-schema and dry-validation have rich API that we lose if we convert it to primitives. Simple wrapping with Success/Failure will work better. See https://github.com/dry-rb/dry-schema/pull/116