### PR TITLE
Add context to Result

### DIFF
--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -86,13 +86,11 @@ module Dry
       #
       # @api public
       def call(input)
-        Result.new(schema.(input), locale: locale) do |result|
-          context = Concurrent::Map.new
-
+        Result.new(schema.(input), Concurrent::Map.new, locale: locale) do |result|
           rules.each do |rule|
             next if rule.keys.any? { |key| result.error?(key) }
 
-            rule.(self, result, context).failures.each do |failure|
+            rule.(self, result, result.context).failures.each do |failure|
               result.add_error(message_resolver[failure])
             end
           end

--- a/spec/integration/contract/evaluator/using_context_spec.rb
+++ b/spec/integration/contract/evaluator/using_context_spec.rb
@@ -27,5 +27,9 @@ RSpec.describe Dry::Validation::Evaluator, 'using context' do
       expect(contract.(user_id: 3, email: 'john@doe.org').errors.to_h).to eql(user: ['must be jane'])
       expect(contract.(user_id: 312, email: 'john@doe.org').errors.to_h).to eql(email: ['is invalid'])
     end
+
+    it 'exposes context in result' do
+      expect(contract.(user_id: 312, email: 'jane@doe.org').context[:user]).to eql('jane')
+    end
   end
 end


### PR DESCRIPTION
@solnic I think we don't want to pass context around as an option so it's another argument for `Result.new`. I'm not sure if we want to simplify `Result#call` to take context from `result`