### PR TITLE
Add "acceptance" macro

### DIFF
--- a/config/errors.yml
+++ b/config/errors.yml
@@ -1,0 +1,4 @@
+en:
+  dry_validation:
+    errors:
+      acceptance: "must accept %{key}"

--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/validation/contract'
+require 'dry/validation/macros'
 
 module Dry
   # Main library namespace

--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -55,6 +55,7 @@ module Dry
       extend ClassInterface
 
       config.messages.top_namespace = 'dry_validation'
+      config.messages.load_paths << Pathname(__FILE__).join('../../../../config/errors.yml').realpath
 
       # @!attribute [r] config
       #   @return [Config]

--- a/lib/dry/validation/contract/class_interface.rb
+++ b/lib/dry/validation/contract/class_interface.rb
@@ -72,12 +72,13 @@ module Dry
         #     failure('please provide a valid street address') if valid_street?(values[:street])
         #   end
         #
-        # @return [Array<Rule>]
+        # @return [Rule]
         #
         # @api public
         def rule(*keys, &block)
-          rules << Rule.new(keys: keys, block: block)
-          rules
+          Rule.new(keys: keys, block: block).tap do |rule|
+            rules << rule
+          end
         end
 
         # A shortcut that can be used to define contracts that won't be reused or inherited

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -64,6 +64,11 @@ module Dry
       #   @api private
       option :keys
 
+      # @!attribute [r] macros
+      #   @return [Array<Symbol>]
+      #   @api private
+      option :macros, optional: true, default: proc { EMPTY_ARRAY.dup }
+
       # @!attribute [r] _context
       #   @return [Concurrent::Map]
       #   @api public
@@ -84,7 +89,12 @@ module Dry
       # @api private
       def initialize(*args, &block)
         super(*args)
-        instance_exec(_context, &block)
+
+        instance_exec(_context, &block) if block
+
+        macros.each do |macro|
+          instance_exec(_context, &Macros[macro])
+        end
       end
 
       # Get failures object for the default or provided path

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -133,6 +133,15 @@ module Dry
         failures
       end
 
+      # Return default (first) key name
+      #
+      # @return [Symbol]
+      #
+      # @api public
+      def key_name
+        @key_name ||= keys.first
+      end
+
       # @api private
       def respond_to_missing?(meth, include_private = false)
         super || _contract.respond_to?(meth, true)

--- a/lib/dry/validation/macros.rb
+++ b/lib/dry/validation/macros.rb
@@ -1,24 +1,19 @@
 # frozen_string_literal: true
 
+require 'dry/container/mixin'
+
 module Dry
   module Validation
     module Macros
-      # @api public
-      module Acceptance
-        # @api public
-        module RuleMethods
-          # @api public
-          def acceptance
-            key_name = keys[0]
+      extend Container::Mixin
 
-            @block = proc do
-              key.failure(:acceptance, key: key_name) unless values[key_name].equal?(true)
-            end
-          end
-        end
+      # @api public
+      Acceptance = proc do
+        key_name = keys[0]
+        key.failure(:acceptance, key: key_name) unless values[key_name].equal?(true)
       end
 
-      Rule.include(Acceptance::RuleMethods)
+      register(:acceptance, Acceptance, call: false)
     end
   end
 end

--- a/lib/dry/validation/macros.rb
+++ b/lib/dry/validation/macros.rb
@@ -19,7 +19,6 @@ module Dry
       #
       # @api public
       register(:acceptance) do
-        key_name = keys[0]
         key.failure(:acceptance, key: key_name) unless values[key_name].equal?(true)
       end
     end

--- a/lib/dry/validation/macros.rb
+++ b/lib/dry/validation/macros.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Dry
+  module Validation
+    module Macros
+      # @api public
+      module Acceptance
+        # @api public
+        module RuleMethods
+          # @api public
+          def acceptance
+            @block = proc do
+              key.failure('must accept terms') unless values[keys[0]].equal?(true)
+            end
+          end
+        end
+      end
+
+      Rule.include(Acceptance::RuleMethods)
+    end
+  end
+end

--- a/lib/dry/validation/macros.rb
+++ b/lib/dry/validation/macros.rb
@@ -4,16 +4,24 @@ require 'dry/container/mixin'
 
 module Dry
   module Validation
+    # API for registering and accessing Rule macros
+    #
+    # @api public
     module Macros
       extend Container::Mixin
 
       # @api public
-      Acceptance = proc do
+      def self.register(name, &block)
+        super(name, block, call: false)
+      end
+
+      # Acceptance macro
+      #
+      # @api public
+      register(:acceptance) do
         key_name = keys[0]
         key.failure(:acceptance, key: key_name) unless values[key_name].equal?(true)
       end
-
-      register(:acceptance, Acceptance, call: false)
     end
   end
 end

--- a/lib/dry/validation/macros.rb
+++ b/lib/dry/validation/macros.rb
@@ -9,8 +9,10 @@ module Dry
         module RuleMethods
           # @api public
           def acceptance
+            key_name = keys[0]
+
             @block = proc do
-              key.failure('must accept terms') unless values[keys[0]].equal?(true)
+              key.failure(:acceptance, key: key_name) unless values[key_name].equal?(true)
             end
           end
         end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -3,6 +3,8 @@
 require 'dry/equalizer'
 require 'dry/initializer'
 
+require 'dry/validation/constants'
+
 module Dry
   module Validation
     # Rules are created by contracts
@@ -18,6 +20,11 @@ module Dry
       #   @api private
       option :keys
 
+      # @!atrribute [r] macros
+      #   @return [Array<Symbol>]
+      #   @api private
+      option :macros, default: proc { EMPTY_ARRAY.dup }
+
       # @!atrribute [r] block
       #   @return [Proc]
       #   @api private
@@ -32,9 +39,20 @@ module Dry
       def call(contract, result)
         Evaluator.new(
           contract,
-          values: result.values, keys: keys, _context: result.context,
+          values: result.values, keys: keys, macros: macros, _context: result.context,
           &block
         )
+      end
+
+      # Define which macros should be executed
+      #
+      # @return [Rule]
+      #
+      # @api public
+      def validate(*macros, &block)
+        @macros = macros
+        @block = block if block
+        self
       end
 
       # Return a nice string representation

--- a/spec/integration/macros/accepted_spec.rb
+++ b/spec/integration/macros/accepted_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Dry::Validation::Macros::Acceptance do
+  subject(:contract) do
+    Dry::Validation::Contract.build do
+      schema do
+        required(:terms).value(:bool)
+      end
+
+      rule(:terms).acceptance
+    end
+  end
+
+  it 'succeeds when value is true' do
+    expect(contract.(terms: true)).to be_success
+  end
+
+  it 'fails when value is not true' do
+    expect(contract.(terms: false).errors.to_h).to eql(terms: ['must accept terms'])
+  end
+end

--- a/spec/integration/macros/accepted_spec.rb
+++ b/spec/integration/macros/accepted_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Dry::Validation::Macros::Acceptance do
+RSpec.describe Dry::Validation::Macros, ':acceptance' do
   subject(:contract) do
     Dry::Validation::Contract.build do
       schema do

--- a/spec/integration/macros/accepted_spec.rb
+++ b/spec/integration/macros/accepted_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Dry::Validation::Macros::Acceptance do
         required(:terms).value(:bool)
       end
 
-      rule(:terms).acceptance
+      rule(:terms).validate(:acceptance)
     end
   end
 


### PR DESCRIPTION
This adds a simple API for registering macros and the first macro called `:acceptance`.

``` ruby
# register a custom macro
Dry::Validation::Macros.register(:even_numbers) do
  key.failure("all numbers must be even because reasons") unless values[key_name].all?(&:even?)
end

# now you can use it

class MyContract < Dry::Validation::Contract
  params do
    required(:numbers).array(:integer)
  end

  rule(:numbers).validate(:even_numbers)
end

mc = MyContract.new

mc.(numbers: ['2'])
# => #<Dry::Validation::Result{:numbers=>[2]} errors={}>

mc.(numbers: ['1'])
# => #<Dry::Validation::Result{:numbers=>[1]} errors={:numbers=>["all numbers must be even because reasons"]}>
```

❗️ `Rule#validate` can accept one or more macro identifiers. ❗️ 
❗️ Macro functions are evaluated via `Evaluator`, so they act as normal rule validation blocks❗️ 

Closes #157 