### PR TITLE
Display the whole path for errors

### DIFF
--- a/lib/dry/validation/messages/resolver.rb
+++ b/lib/dry/validation/messages/resolver.rb
@@ -68,7 +68,7 @@ module Dry
 
           unless template
             raise MissingMessageError, <<~STR
-              Message template for #{rule.inspect} under #{keys.join(DOT).inspect} was not found
+              Message template for #{rule.inspect} under #{messages.rule_lookup_paths(name: rule, locale: locale)} was not found
             STR
           end
 

--- a/spec/integration/messages/resolver_spec.rb
+++ b/spec/integration/messages/resolver_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe Dry::Validation::Messages::Resolver, '#message' do
       end
 
       it 'provides meaningful message when path=[nil]' do
-        if prepend_locale
-          path = "#{locale}.dry_validation.rules.not_here"
-        else
-          path = 'dry_validation.rules.not_here'
-        end
+        path = if prepend_locale
+                 "#{locale}.dry_validation.rules.not_here"
+               else
+                 'dry_validation.rules.not_here'
+               end
 
         expect { resolver.message(:not_here, path: [nil]) }
           .to raise_error(Dry::Validation::MissingMessageError, <<~STR)
@@ -54,11 +54,11 @@ RSpec.describe Dry::Validation::Messages::Resolver, '#message' do
       end
 
       it 'raises error when template was not found' do
-        if prepend_locale
-          path = "#{locale}.dry_validation.rules.not_here"
-        else
-          path = 'dry_validation.rules.not_here'
-        end
+        path = if prepend_locale
+                 "#{locale}.dry_validation.rules.not_here"
+               else
+                 'dry_validation.rules.not_here'
+               end
 
         expect { resolver.message(:not_here, path: [:email]) }
           .to raise_error(Dry::Validation::MissingMessageError, <<~STR)


### PR DESCRIPTION
Before:

I had a code that looked like this:

```ruby
rule do
  base.failure(:expired)
end
```

which returned this error:

```
       Message template for :expired under "" was not found
```

I figured it would be nice to be a bit more specific and probably display *where* the message was supposed to be. 

Now it says

```
       Message template for :expired under ["dry_validation.rules.expired"] was not found
```

Also, found out that the message's `path` param does not really affect the i18n rule path.

**Beware** I've used Dry::Schema::Message#rule_lookup_paths` which is marked by `@api private`. Probably should be extra considerate about that. 