### PR TITLE
[WIP] [FIX] I18n fails for symbolized base rule failures

### DIFF
--- a/spec/fixtures/messages/errors.en.yml
+++ b/spec/fixtures/messages/errors.en.yml
@@ -2,6 +2,7 @@ en:
   dry_validation:
     rules:
       email: "E-mail"
+      not_good_enough: "Email should be nicer"
     errors:
       rules:
         not_weekend: "this only works on weekends"

--- a/spec/integration/contract/evaluator/failure_spec.rb
+++ b/spec/integration/contract/evaluator/failure_spec.rb
@@ -67,14 +67,28 @@ RSpec.describe Dry::Validation::Evaluator do
   end
 
   context 'setting base failures' do
-    before do
-      contract_class.rule(:email) do
-        base.failure('is invalid')
+    context 'string failure' do
+      before do
+        contract_class.rule(:email) do
+          base.failure('is invalid')
+        end
+      end
+
+      it 'sets error under specified key' do
+        expect(contract.(email: 'foo').errors.to_h).to eql(nil => ['is invalid'])
       end
     end
 
-    it 'sets error under specified key' do
-      expect(contract.(email: 'foo').errors.to_h).to eql(nil => ['is invalid'])
+    context 'symbol failure' do
+      before do
+        contract_class.rule(:email) do
+          base.failure(:not_good_enough)
+        end
+      end
+
+      it 'sets error under specified key' do
+        expect(contract.(email: 'foo').errors.to_h).to eql(nil => ['Email should be nicer'])
+      end
     end
   end
 


### PR DESCRIPTION
```
rule do
  base.failure(:foo)
end
```

Fails with `       Message template for :not_good_enough under "" was not found` even if the locale string is present.

I'm fixing it at the moment. Any suggestions are welcome