### PR TITLE
Rules for arrays

### DIFF
--- a/lib/dry/validation/constants.rb
+++ b/lib/dry/validation/constants.rb
@@ -8,6 +8,9 @@ module Dry
 
     DOT = '.'
 
+    # Root path is used for base errors in hash representation of error messages
+    ROOT_PATH = [nil].freeze
+
     # Error raised when `rule` specifies one or more keys that the schema doesn't specify
     InvalidKeysError = Class.new(StandardError)
 

--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -95,7 +95,9 @@ module Dry
           rules.each do |rule|
             next if rule.keys.any? { |key| error?(result, key) }
 
-            rule.(self, result).failures.each do |failure|
+            r = rule.(self, result)
+
+            r.failures.each do |failure|
               result.add_error(message_resolver[failure])
             end
           end

--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -95,9 +95,9 @@ module Dry
           rules.each do |rule|
             next if rule.keys.any? { |key| error?(result, key) }
 
-            r = rule.(self, result)
+            rule_result = rule.(self, result)
 
-            r.failures.each do |failure|
+            rule_result.failures.each do |failure|
               result.add_error(message_resolver[failure])
             end
           end

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -122,6 +122,24 @@ module Dry
         @key_name ||= keys.first
       end
 
+      # Return the value found under the first specified key
+      #
+      # This is a convenient method that can be used in all the common cases
+      # where a rule depends on just one key and you want a quick access to
+      # the value
+      #
+      # @example
+      #   rule(:age) do
+      #     key.failure(:invalid) if value < 18
+      #   end
+      #
+      # @return [Object]
+      #
+      # @public
+      def value
+        values[key_name]
+      end
+
       # Check if there are any errors under the provided path
       #
       # @param [Symbol, String, Array] A Path-compatible spec

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -139,6 +139,17 @@ module Dry
         @failures
       end
 
+      # @api private
+      def with(new_opts, &block)
+        options = {
+          _context: _context,
+          result: result,
+          values: values
+        }.merge(new_opts)
+
+        Evaluator.new(_contract, options, &block)
+      end
+
       # Return default (first) key name
       #
       # @return [Symbol]

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -59,6 +59,11 @@ module Dry
       #   @api private
       param :_contract
 
+      # @!attribute [r] result
+      #   @return [Result]
+      #   @api private
+      option :result
+
       # @!attribute [r] keys
       #   @return [Array<String, Symbol, Hash>]
       #   @api private
@@ -128,10 +133,10 @@ module Dry
       #
       # @api private
       def failures
-        failures = []
-        failures += @base.opts if defined?(@base)
-        failures.concat(@key.values.flat_map(&:opts)) if defined?(@key)
-        failures
+        @failures ||= []
+        @failures += @base.opts if defined?(@base)
+        @failures.concat(@key.values.flat_map(&:opts)) if defined?(@key)
+        @failures
       end
 
       # Return default (first) key name
@@ -141,6 +146,17 @@ module Dry
       # @api public
       def key_name
         @key_name ||= keys.first
+      end
+
+      # Check if there are any errors under the provided path
+      #
+      # @param [Symbol, String, Array] A Path-compatible spec
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def error?(path)
+        result.error?(path)
       end
 
       # @api private

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'dry/initializer'
+
 require 'dry/validation/constants'
+require 'dry/validation/failures'
 
 module Dry
   module Validation
@@ -14,45 +16,6 @@ module Dry
     # @api public
     class Evaluator
       extend Dry::Initializer
-
-      ROOT_PATH = [nil].freeze
-
-      # Failure accumulator object
-      #
-      # @api public
-      class Failures
-        # @api private
-        attr_reader :path
-
-        # @api private
-        attr_reader :opts
-
-        # @api private
-        def initialize(path = ROOT_PATH)
-          @path = Dry::Schema::Path[path]
-          @opts = []
-        end
-
-        # Set failure
-        #
-        # @overload failure(message)
-        #   Set message text explicitly
-        #   @param message [String] The message text
-        #   @example
-        #     failure('this failed')
-        #
-        # @overload failure(id)
-        #   Use message identifier (needs localized messages setup)
-        #   @param id [Symbol] The message id
-        #   @example
-        #     failure(:taken)
-        #
-        # @api public
-        def failure(message, tokens = EMPTY_HASH)
-          @opts << { message: message, tokens: tokens, path: path }
-          self
-        end
-      end
 
       # @!attribute [r] _contract
       #   @return [Contract]

--- a/lib/dry/validation/failures.rb
+++ b/lib/dry/validation/failures.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'dry/schema/path'
+require 'dry/validation/constants'
+
+module Dry
+  module Validation
+    # Failure accumulator object
+    #
+    # @api public
+    class Failures
+      # The path for messages accumulated by failures object
+      #
+      # @return [Dry::Schema::Path]
+      #
+      # @api private
+      attr_reader :path
+
+      # Options for messages
+      #
+      # These options are used by MessageResolver
+      #
+      # @return [Hash]
+      #
+      # @api private
+      attr_reader :opts
+
+      # @api private
+      def initialize(path = ROOT_PATH)
+        @path = Dry::Schema::Path[path]
+        @opts = []
+      end
+
+      # Set failure
+      #
+      # @overload failure(message)
+      #   Set message text explicitly
+      #   @param message [String] The message text
+      #   @example
+      #     failure('this failed')
+      #
+      # @overload failure(id)
+      #   Use message identifier (needs localized messages setup)
+      #   @param id [Symbol] The message id
+      #   @example
+      #     failure(:taken)
+      #
+      # @see Evaluator#key
+      # @see Evaluator#base
+      #
+      # @api public
+      def failure(message, tokens = EMPTY_HASH)
+        @opts << { message: message, tokens: tokens, path: path }
+        self
+      end
+    end
+  end
+end

--- a/lib/dry/validation/failures.rb
+++ b/lib/dry/validation/failures.rb
@@ -28,7 +28,7 @@ module Dry
       # @api private
       def initialize(path = ROOT_PATH)
         @path = Dry::Schema::Path[path]
-        @opts = []
+        @opts = EMPTY_ARRAY.dup
       end
 
       # Set failure
@@ -50,7 +50,7 @@ module Dry
       #
       # @api public
       def failure(message, tokens = EMPTY_HASH)
-        @opts << { message: message, tokens: tokens, path: path }
+        opts << { message: message, tokens: tokens, path: path }
         self
       end
     end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -74,14 +74,7 @@ module Dry
 
             next if result.error?(path)
 
-            evaluator = Evaluator.new(
-              _contract,
-              _context: value,
-              result: result,
-              values: values,
-              keys: [path],
-              &block
-            )
+            evaluator = with(_context: value, keys: [path], &block)
 
             failures.concat(evaluator.failures)
           end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -83,12 +83,12 @@ module Dry
         @keys = []
 
         @block = proc do
-          values[root].each_with_index do |value, idx|
+          values[root].each_with_index do |_, idx|
             path = [*root, idx]
 
             next if result.error?(path)
 
-            evaluator = with(_context: value, keys: [path], &block)
+            evaluator = with(keys: [path], &block)
 
             failures.concat(evaluator.failures)
           end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -71,7 +71,7 @@ module Dry
       # for a given array item.
       #
       # @example
-      #   rule(:nums).each do |value|
+      #   rule(:nums).each do
       #     key.failure("must be greater than 0") if value < 0
       #   end
       #

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -68,6 +68,8 @@ module Dry
       # @api public
       def each(&block)
         root = keys
+        @keys = []
+
         @block = proc do
           values[root].each_with_index do |value, idx|
             path = [*root, idx]
@@ -79,7 +81,7 @@ module Dry
             failures.concat(evaluator.failures)
           end
         end
-        @keys = []
+
         self
       end
 

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -65,6 +65,18 @@ module Dry
         self
       end
 
+      # Define a validation function for each element of an array
+      #
+      # The function will be applied only if schema checks passed
+      # for a given array item.
+      #
+      # @example
+      #   rule(:nums).each do |value|
+      #     key.failure("must be greater than 0") if value < 0
+      #   end
+      #
+      # @return [Rule]
+      #
       # @api public
       def each(&block)
         root = keys

--- a/spec/integration/contract/call_spec.rb
+++ b/spec/integration/contract/call_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Dry::Validation::Contract, '#call' do
       end
 
       rule(:age) do
-        key.failure('must be greater or equal 18') if values[:age] < 18
+        key.failure('must be greater or equal 18') if value < 18
       end
 
       rule(:age) do
-        key.failure('must be greater than 0') if values[:age] < 0
+        key.failure('must be greater than 0') if value < 0
       end
 
       rule(address: :zip) do

--- a/spec/integration/contract/class_interface/rule/array_spec.rb
+++ b/spec/integration/contract/class_interface/rule/array_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'dry/validation/contract'
+
+RSpec.describe Dry::Validation::Contract, 'Rule#each' do
+  subject(:contract) { contract_class.new }
+
+  let(:contract_class) do
+    Class.new(Dry::Validation::Contract) do
+      def self.name
+        'TestContract'
+      end
+
+      params do
+        required(:nums).array(:integer)
+      end
+
+      rule(:nums).each do |value|
+        key.failure('invalid') if value < 3
+      end
+    end
+  end
+
+  context 'when the value is an array' do
+    it 'applies rule when an item passed schema checks' do
+      expect(contract.(nums: ['oops', 1, 4]).errors.to_h)
+        .to eql(nums: { 0 => ['must be an integer'], 1 => ['invalid']})
+    end
+  end
+end

--- a/spec/integration/contract/class_interface/rule/array_spec.rb
+++ b/spec/integration/contract/class_interface/rule/array_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Dry::Validation::Contract, 'Rule#each' do
 
   context 'when the value is an array' do
     it 'applies rule when an item passed schema checks' do
-      expect(contract.(nums: ['oops', 1, 4]).errors.to_h)
-        .to eql(nums: { 0 => ['must be an integer'], 1 => ['invalid']})
+      expect(contract.(nums: ['oops', 1, 4, 0]).errors.to_h)
+        .to eql(nums: { 0 => ['must be an integer'], 1 => ['invalid'], 3 => ['invalid']})
     end
   end
 end

--- a/spec/integration/contract/class_interface/rule/array_spec.rb
+++ b/spec/integration/contract/class_interface/rule/array_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Dry::Validation::Contract, 'Rule#each' do
         required(:nums).array(:integer)
       end
 
-      rule(:nums).each do |value|
+      rule(:nums).each do
         key.failure('invalid') if value < 3
       end
     end

--- a/spec/integration/evaluator_spec.rb
+++ b/spec/integration/evaluator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Dry::Validation::Evaluator do
   end
 
   let(:options) do
-    { keys: [:email], values: values, _context: {} }
+    { keys: [:email], result: {}, values: values, _context: {} }
   end
 
   let(:values) do


### PR DESCRIPTION
This adds a convenient method for validating elements of an array. Just like with any other rule, the validation function is only applied when schema checks passed **for a given value**.

``` ruby
require 'dry/validation'

class Props < Dry::Validation::Contract
  params do
    required(:props).array(:string)
  end  
  
  rule(:props).each do
    key.failure('bad format') unless /[a-z]+/.match?(value)
  end  
end  

props_contract = Props.new

props_contract.(props: ['foo', 1, '1234', 'hello']).errors.to_h
# {:props=>{1=>["must be a string"], 2=>["bad format"]}}
```

As a bonus, I added `Evaluator#value` which returns the value under the first key, which is a nice general addition useful in all rule types.