### PR TITLE
Use kwargs in rule and macro functions

### DIFF
--- a/lib/dry/validation/constants.rb
+++ b/lib/dry/validation/constants.rb
@@ -11,6 +11,11 @@ module Dry
     # Root path is used for base errors in hash representation of error messages
     ROOT_PATH = [nil].freeze
 
+    # Mapping for block kwarg options used by block_options
+    #
+    # @see Rule#block_options
+    BLOCK_OPTIONS_MAPPINGS = Hash.new { |_, key| key }.update(context: :_context).freeze
+
     # Error raised when `rule` specifies one or more keys that the schema doesn't specify
     InvalidKeysError = Class.new(StandardError)
 

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -52,17 +52,24 @@ module Dry
       #   @api private
       option :values
 
+      # @!attribute [r] block_options
+      #   @return [Hash<Symbol=>Symbol>]
+      #   @api private
+      option :block_options, default: proc { EMPTY_HASH }
+
       # Initialize a new evaluator
       #
       # @api private
       def initialize(*args, &block)
         super(*args)
 
-        instance_exec(_context, &block) if block
+        exec_opts = block_options.map { |key, value| [key, public_send(value)] }.to_h
+
+        instance_exec(exec_opts, &block) if block
 
         macros.each do |args|
           macro = macro(*args.flatten(1))
-          instance_exec(_context, macro, &macro.block)
+          instance_exec(exec_opts.merge(macro: macro), &macro.block)
         end
       end
 

--- a/lib/dry/validation/function.rb
+++ b/lib/dry/validation/function.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'dry/initializer'
+require 'dry/validation/constants'
+
+module Dry
+  module Validation
+    # Abstract class for handling rule blocks
+    #
+    # @see Rule
+    # @see Macro
+    #
+    # @api private
+    class Function
+      extend Dry::Initializer
+
+      # @!attribute [r] block
+      #   @return [Proc]
+      #   @api private
+      option :block
+
+      private
+
+      # Extract options for the block kwargs
+      #
+      # @return [Hash]
+      #
+      # @api private
+      def block_options
+        return EMPTY_HASH unless block
+
+        @block_options ||= block
+          .parameters
+          .select { |arg| arg[0].equal?(:keyreq) }
+          .map(&:last)
+          .map { |name| [name, BLOCK_OPTIONS_MAPPINGS[name]] }
+          .to_h
+      end
+    end
+  end
+end

--- a/lib/dry/validation/macro.rb
+++ b/lib/dry/validation/macro.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 require 'dry/validation/constants'
+require 'dry/validation/function'
 
 module Dry
   module Validation
     # A wrapper for macro validation blocks
     #
     # @api public
-    class Macro
-      extend Dry::Initializer
-
+    class Macro < Function
       # @!attribute [r] name
       #   @return [Symbol]
       #   @api public
@@ -33,18 +32,6 @@ module Dry
       # @api private
       def extract_block_options(options)
         block_options.map { |key, value| [key, options[value]] }.to_h
-      end
-
-      private
-
-      # @api private
-      def block_options
-        @block_options ||= block
-          .parameters
-          .select { |arg| arg[0].equal?(:keyreq) }
-          .map(&:last)
-          .map { |name| [name, BLOCK_OPTIONS_MAPPINGS[name]] }
-          .to_h
       end
     end
   end

--- a/lib/dry/validation/macro.rb
+++ b/lib/dry/validation/macro.rb
@@ -27,6 +27,23 @@ module Dry
       def with(args)
         self.class.new(name, args: args, block: block)
       end
+
+      # @api private
+      def extract_block_options(options)
+        block_options.map { |key, value| [key, options[value]] }.to_h
+      end
+
+      private
+
+      # @api private
+      def block_options
+        @block_options ||= block
+          .parameters
+          .select { |arg| arg[0].equal?(:keyreq) }
+          .map(&:last)
+          .map { |name| [name, Rule::BLOCK_OPTIONS_MAPPINGS[name]] }
+          .to_h
+      end
     end
   end
 end

--- a/lib/dry/validation/macro.rb
+++ b/lib/dry/validation/macro.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dry/validation/constants'
+
 module Dry
   module Validation
     # A wrapper for macro validation blocks
@@ -41,7 +43,7 @@ module Dry
           .parameters
           .select { |arg| arg[0].equal?(:keyreq) }
           .map(&:last)
-          .map { |name| [name, Rule::BLOCK_OPTIONS_MAPPINGS[name]] }
+          .map { |name| [name, BLOCK_OPTIONS_MAPPINGS[name]] }
           .to_h
       end
     end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -20,11 +20,6 @@ module Dry
 
       extend Dry::Initializer
 
-      # Mapping for block kwarg options used by block_options
-      #
-      # @see Rule#block_options
-      BLOCK_OPTIONS_MAPPINGS = Hash.new { |_, key| key }.update(context: :_context).freeze
-
       # @!attribute [r] keys
       #   @return [Array<Symbol, String, Hash>]
       #   @api private

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -20,6 +20,11 @@ module Dry
 
       extend Dry::Initializer
 
+      # Mapping for block kwarg options used by block_options
+      #
+      # @see Rule#block_options
+      BLOCK_OPTIONS_MAPPINGS = Hash.new { |_, key| key }.update(context: :_context).freeze
+
       # @!attribute [r] keys
       #   @return [Array<Symbol, String, Hash>]
       #   @api private
@@ -46,6 +51,7 @@ module Dry
           contract,
           keys: keys,
           macros: macros,
+          block_options: block_options,
           result: result,
           values: result.values,
           _context: result.context,
@@ -104,6 +110,22 @@ module Dry
       # @api public
       def inspect
         %(#<#{self.class} keys=#{keys.inspect}>)
+      end
+
+      # Extract options for the block kwargs
+      #
+      # @return [Hash]
+      #
+      # @api private
+      def block_options
+        return EMPTY_HASH unless block
+
+        @block_options ||= block
+          .parameters
+          .select { |arg| arg[0].equal?(:keyreq) }
+          .map(&:last)
+          .map { |name| [name, BLOCK_OPTIONS_MAPPINGS[name]] }
+          .to_h
       end
     end
   end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require 'dry/equalizer'
-require 'dry/initializer'
 
 require 'dry/validation/constants'
+require 'dry/validation/function'
 
 module Dry
   module Validation
@@ -15,10 +15,8 @@ module Dry
     # @see Contract#rule
     #
     # @api public
-    class Rule
+    class Rule < Function
       include Dry::Equalizer(:keys, :block, inspect: false)
-
-      extend Dry::Initializer
 
       # @!attribute [r] keys
       #   @return [Array<Symbol, String, Hash>]
@@ -29,11 +27,6 @@ module Dry
       #   @return [Array<Symbol>]
       #   @api private
       option :macros, default: proc { EMPTY_ARRAY.dup }
-
-      # @!attribute [r] block
-      #   @return [Proc]
-      #   @api private
-      option :block
 
       # Evaluate the rule within the provided context
       #
@@ -105,22 +98,6 @@ module Dry
       # @api public
       def inspect
         %(#<#{self.class} keys=#{keys.inspect}>)
-      end
-
-      # Extract options for the block kwargs
-      #
-      # @return [Hash]
-      #
-      # @api private
-      def block_options
-        return EMPTY_HASH unless block
-
-        @block_options ||= block
-          .parameters
-          .select { |arg| arg[0].equal?(:keyreq) }
-          .map(&:last)
-          .map { |name| [name, BLOCK_OPTIONS_MAPPINGS[name]] }
-          .to_h
       end
     end
   end

--- a/spec/integration/contract/evaluator/using_context_spec.rb
+++ b/spec/integration/contract/evaluator/using_context_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe Dry::Validation::Evaluator, 'using context' do
           required(:user_id).filled(:integer)
         end
 
-        rule(:user_id) do |ctx|
+        rule(:user_id) do |context:|
           if values[:user_id].equal?(312)
-            ctx[:user] = 'jane'
+            context[:user] = 'jane'
           else
             key(:user).failure('must be jane')
           end
         end
 
-        rule(:email) do |ctx|
-          key.failure('is invalid') if ctx[:user] == 'jane' && values[:email] != 'jane@doe.org'
+        rule(:email) do |context:|
+          key.failure('is invalid') if context[:user] == 'jane' && values[:email] != 'jane@doe.org'
         end
       end
     end

--- a/spec/integration/contract/evaluator/using_context_spec.rb
+++ b/spec/integration/contract/evaluator/using_context_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dry::Validation::Evaluator, 'using context' do
 
   context 'when key does not exist' do
     subject(:contract) do
-      Dry::Validation::Contract.build do
+      Dry::Validation.Contract do
         schema do
           required(:email).filled(:string)
           required(:user_id).filled(:integer)

--- a/spec/integration/macros/custom_macros_spec.rb
+++ b/spec/integration/macros/custom_macros_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Defining custom macros' do
 
   context 'using a macro with options' do
     before do
-      Test::BaseContract.register_macro(:min) do |_, macro|
+      Test::BaseContract.register_macro(:min) do |macro:|
         num = macro.args[0]
 
         key.failure("must have at least #{num} items") unless values[key_name].size >= num

--- a/spec/integration/macros/custom_macros_spec.rb
+++ b/spec/integration/macros/custom_macros_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Defining custom macros' do
 
   context 'using a macro with options' do
     before do
-      Test::BaseContract.register_macro(:min) do |macro:|
+      Test::BaseContract.register_macro(:min) do |context:, macro:|
         num = macro.args[0]
 
         key.failure("must have at least #{num} items") unless values[key_name].size >= num


### PR DESCRIPTION
This makes rule block arguments more flexible, instead of using positioned arguments (which was `|context|` or `|context, macro|` for blocks used from macros) we have a "dynamic" kwarg approach. By defining kwargs in your blocks you specify what you need in your blocks.

## TODO

- [x] make it work with evaluator blocks
- [x] make it work with macro blocks