### PR TITLE
Extension to use dry-logic predicates as macros

### DIFF
--- a/dry-validation.gemspec
+++ b/dry-validation.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-container', '~> 0.7', '>= 0.7.1'
   spec.add_runtime_dependency 'dry-initializer', '~> 3.0'
-  spec.add_runtime_dependency 'dry-schema', '~> 1.0', '>= 1.1.0'
+  spec.add_runtime_dependency 'dry-schema', '~> 1.0', '>= 1.2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -23,6 +23,10 @@ module Dry
       require 'dry/validation/extensions/hints'
     end
 
+    register_extension(:predicates_as_macros) do
+      require 'dry/validation/extensions/predicates_as_macros'
+    end
+
     # Define a contract and build its instance
     #
     # @example

--- a/lib/dry/validation/extensions/predicates_as_macros.rb
+++ b/lib/dry/validation/extensions/predicates_as_macros.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require 'dry/logic/predicates'
+require 'dry/schema/predicate_registry'
+require 'dry/validation/contract'
+
 module Dry
   module Validation
     # Encapsulation of a dry-logic predicate.

--- a/lib/dry/validation/extensions/predicates_as_macros.rb
+++ b/lib/dry/validation/extensions/predicates_as_macros.rb
@@ -11,7 +11,10 @@ module Dry
       # List of predicates to be imported.
       #
       # @see Dry::Validation::Contract
-      WHITELIST = %i[gteq?].freeze
+      WHITELIST = %i[
+        filled? gt? gteq? included_in? includes? inclusion? is? lt?
+        lteq? max_size? min_size? not_eql? odd? respond_to? size? true?
+      ].freeze
 
       # @api private
       REGISTRY = Dry::Schema::PredicateRegistry.new(

--- a/lib/dry/validation/extensions/predicates_as_macros.rb
+++ b/lib/dry/validation/extensions/predicates_as_macros.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'dry/logic/predicates'
 require 'dry/schema/predicate_registry'
 require 'dry/validation/contract'
 

--- a/lib/dry/validation/extensions/predicates_as_macros.rb
+++ b/lib/dry/validation/extensions/predicates_as_macros.rb
@@ -14,6 +14,7 @@ module Dry
       WHITELIST = %i[
         filled? gt? gteq? included_in? includes? inclusion? is? lt?
         lteq? max_size? min_size? not_eql? odd? respond_to? size? true?
+        uuid_v4?
       ].freeze
 
       # @api private

--- a/lib/dry/validation/extensions/predicates_as_macros.rb
+++ b/lib/dry/validation/extensions/predicates_as_macros.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Dry
+  module Validation
+    # Encapsulation of a dry-logic predicate.
+    class Predicate
+      # List of predicates to be imported.
+      #
+      # @see Dry::Validation::Contract
+      WHITELIST = %i[gteq?].freeze
+
+      # @api private
+      REGISTRY = Dry::Schema::PredicateRegistry.new(
+        Dry::Logic::Predicates
+      ).freeze
+
+      # @api private
+      attr_reader :name
+
+      # @api private
+      def initialize(name)
+        @name = name
+      end
+
+      # @api private
+      def arg_names
+        REGISTRY.arg_list(name).map(&:first)
+      end
+
+      # @api private
+      def call(args)
+        REGISTRY[name].(*args)
+      end
+
+      # @api private
+      def add_failure_from_call(key, arg_values)
+        message_opts = arg_names.zip(arg_values).to_h
+
+        key.failure(name, message_opts)
+      end
+    end
+
+    # Extension to use dry-logic predicates as macros.
+    #
+    # @see Dry::Validation::Predicate::WHITELIST Available predicates
+    #
+    # @example
+    #   Dry::Validation.load_extensions(:predicates_as_macros)
+    #
+    #   class ApplicationContract < Dry::Validation::Contract
+    #     import_predicates_as_macros
+    #   end
+    #
+    #   class AgeContract < ApplicationContract
+    #     schema do
+    #       required(:name).filled(:integer)
+    #     end
+    #
+    #     rule(:age).validate(gteq?: 18)
+    #   end
+    #
+    #   AgeContract.new.(age: 17).errors.first.text
+    #   # => 'must be greater than or equal to 18'
+    class Contract
+      # Make macros available for self and its descendants.
+      def self.import_predicates_as_macros
+        Predicate::WHITELIST.each do |name|
+          predicate = Predicate.new(name)
+          register_macro(name) do |macro:|
+            predicate_args = [*macro.args, value]
+            predicate.(predicate_args) ||
+              predicate.add_failure_from_call(key, predicate_args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/validation/extensions/predicates_as_macros.rb
+++ b/lib/dry/validation/extensions/predicates_as_macros.rb
@@ -62,8 +62,9 @@ module Dry
         PredicateRegistry::WHITELIST.each do |name|
           register_macro(name) do |macro:|
             predicate_args = [*macro.args, value]
-            registry.(name, predicate_args) ||
-              key.failure(name, registry.message_opts(name, predicate_args))
+            key.failure(
+              name, registry.message_opts(name, predicate_args)
+            ) unless registry.(name, predicate_args)
           end
         end
       end

--- a/lib/dry/validation/extensions/predicates_as_macros.rb
+++ b/lib/dry/validation/extensions/predicates_as_macros.rb
@@ -41,10 +41,8 @@ module Dry
       end
 
       # @api private
-      def add_failure_from_call(key, arg_values)
-        message_opts = arg_names.zip(arg_values).to_h
-
-        key.failure(name, message_opts)
+      def message_opts(arg_values)
+        arg_names.zip(arg_values).to_h
       end
     end
 
@@ -77,7 +75,7 @@ module Dry
           register_macro(name) do |macro:|
             predicate_args = [*macro.args, value]
             predicate.(predicate_args) ||
-              predicate.add_failure_from_call(key, predicate_args)
+              key.failure(name, predicate.message_opts(predicate_args))
           end
         end
       end

--- a/spec/extensions/predicates_as_macros/contract_spec.rb
+++ b/spec/extensions/predicates_as_macros/contract_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Dry::Validation::Contract do
     %i[
       filled? gt? gteq? included_in? includes? inclusion? is? lt?
       lteq? max_size? min_size? not_eql? odd? respond_to? size? true?
+      uuid_v4?
     ].each do |predicate|
       it "imports #{predicate}" do
         expect(

--- a/spec/extensions/predicates_as_macros/contract_spec.rb
+++ b/spec/extensions/predicates_as_macros/contract_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dry/validation/extensions/predicates_as_macros'
+
 RSpec.describe Dry::Validation::Contract do
   context 'with predicates_as_macros extension' do
     before { Dry::Validation.load_extensions(:predicates_as_macros) }

--- a/spec/extensions/predicates_as_macros/contract_spec.rb
+++ b/spec/extensions/predicates_as_macros/contract_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Validation::Contract do
+  context 'with predicates_as_macros extension' do
+    before { Dry::Validation.load_extensions(:predicates_as_macros) }
+
+    subject(:contract) do
+      Class.new(Dry::Validation::Contract) do
+        import_predicates_as_macros
+      end
+    end
+
+    %i[gteq?].each do |predicate|
+      it "imports #{predicate}" do
+        expect(contract.macros.key?(predicate)).to be(true)
+      end
+    end
+
+    it 'macros succeed on predicate success' do
+      age_contract = Class.new(contract) do
+        schema do
+          required(:age).filled(:integer)
+        end
+
+        rule(:age).validate(gteq?: 18)
+      end.new
+
+      expect(age_contract.(age: 19)).to be_success
+    end
+
+    it 'macros fail on predicate failure' do
+      age_contract = Class.new(contract) do
+        schema do
+          required(:age).filled(:integer)
+        end
+
+        rule(:age).validate(gteq?: 18)
+      end.new
+
+      expect(age_contract.(age: 17)).to be_failure
+    end
+
+    it 'failure message is built from predicate name and arguments' do
+      age_contract = Class.new(contract) do
+        schema do
+          required(:age).filled(:integer)
+        end
+
+        rule(:age).validate(gteq?: 18)
+      end.new
+
+      result = age_contract.(age: 17)
+
+      expect(
+        result.errors.first.text
+      ).to eq('must be greater than or equal to 18')
+    end
+  end
+end

--- a/spec/extensions/predicates_as_macros/contract_spec.rb
+++ b/spec/extensions/predicates_as_macros/contract_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Dry::Validation::Contract do
       end
     end
 
-    let(:registry) { Dry::Validation::Predicate::REGISTRY }
+    let(:registry) { Dry::Validation::PredicateRegistry.new }
 
     %i[
       filled? gt? gteq? included_in? includes? inclusion? is? lt?

--- a/spec/extensions/predicates_as_macros/contract_spec.rb
+++ b/spec/extensions/predicates_as_macros/contract_spec.rb
@@ -12,9 +12,16 @@ RSpec.describe Dry::Validation::Contract do
       end
     end
 
-    %i[gteq?].each do |predicate|
+    let(:registry) { Dry::Validation::Predicate::REGISTRY }
+
+    %i[
+      filled? gt? gteq? included_in? includes? inclusion? is? lt?
+      lteq? max_size? min_size? not_eql? odd? respond_to? size? true?
+    ].each do |predicate|
       it "imports #{predicate}" do
-        expect(contract.macros.key?(predicate)).to be(true)
+        expect(
+          registry.key?(predicate) && contract.macros.key?(predicate)
+        ).to be(true)
       end
     end
 


### PR DESCRIPTION
PoC for `:gteq?`

This is the implementation for #537 

Some considerations:

- Right now it just loads with `:gteq?` predicate. We have to decide which predicates need to be imported. My proposal is:

  - empty?
  - filled?
  - odd?
  - even?
  - lt?
  - gt?
  - lteq?
  - gteq?
  - size?
  - min_size?
  - max_size?
  - inclusion?
  - exclusion?
  - included_in?
  - excluded_from?
  - includes?
  - excludes?
  - eql?
  - is?
  - not_eql?
  - true?
  - false?
  - uuid_v4?
  - respond_to?

- I think `Dry::Validation::Predicate#arg_names` and `Dry::Validation::Predicate#call` should be moved to `Dry::Schema::PredicateRegistry`.

- I think it would be nice to keep `name` and `options` in the generated error when doing `.failure(name, options)`. If I'm understanding what it is happening, they are just used as an intermediate info to build the error message (`must be greater than...` in this case). This way I could test what I want to test (that I provide that information) and not have to rely on the message generation, which makes me depend on the yaml, etc..

- Surely it has been discussed before, but I feel it is a duplication being able to use predicates in `dry-schema`. I think that `dry-schema` should only be concerned with structure and types, while `dry-validation` should deal with values.

Thanks for any feedback.