### PR TITLE
Add key? method to rule blocks

### DIFF
--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -153,13 +153,13 @@ module Dry
       #
       # @example
       #   rule(:age) do
-      #     key.failure(:invalid) if value? && value < 18
+      #     key.failure(:invalid) if key? && value < 18
       #   end
       #
       # @return [Boolean]
       #
       # @api public
-      def value?
+      def key?
         values.key?(key_name)
       end
 

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -147,6 +147,22 @@ module Dry
         values[key_name]
       end
 
+      # Return if the value under the default key is available
+      #
+      # This is useful when dealing with rules for optional keys
+      #
+      # @example
+      #   rule(:age) do
+      #     key.failure(:invalid) if value? && value < 18
+      #   end
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def value?
+        values.key?(key_name)
+      end
+
       # Check if there are any errors under the provided path
       #
       # @param [Symbol, String, Array] A Path-compatible spec

--- a/lib/dry/validation/values.rb
+++ b/lib/dry/validation/values.rb
@@ -68,7 +68,7 @@ module Dry
             result = e.all? { |k| key?(k, a) }
             return result
           else
-            return false unless a.key?(e)
+            return false unless a.is_a?(Array) ? (0..a.size-1).cover?(e) : a.key?(e)
           end
           a[e]
         end

--- a/lib/dry/validation/values.rb
+++ b/lib/dry/validation/values.rb
@@ -51,6 +51,18 @@ module Dry
         end
       end
 
+      # @api public
+      def key?(key)
+        return data.key?(key) if key.is_a?(Symbol)
+
+        Schema::Path[key].reduce(data) do |a, e|
+          return false unless a.key?(e)
+          a[e]
+        end
+
+        true
+      end
+
       # @api private
       def respond_to_missing?(meth, include_private = false)
         super || data.respond_to?(meth, include_private)

--- a/lib/dry/validation/values.rb
+++ b/lib/dry/validation/values.rb
@@ -45,7 +45,15 @@ module Dry
 
         case (key = args[0])
         when Symbol, String, Array, Hash
-          data.dig(*Schema::Path[key].to_a)
+          path = Schema::Path[key]
+          keys = path.to_a
+
+          return data.dig(*keys) unless keys.last.is_a?(Array)
+
+          last = keys.pop
+          vals = self.class.new(data.dig(*keys))
+
+          last.map { |name| vals[name] }
         else
           raise ArgumentError, '+key+ must be a valid path specification'
         end

--- a/lib/dry/validation/values.rb
+++ b/lib/dry/validation/values.rb
@@ -68,7 +68,7 @@ module Dry
             result = e.all? { |k| key?(k, a) }
             return result
           else
-            return false unless a.is_a?(Array) ? (0..a.size-1).cover?(e) : a.key?(e)
+            return false unless a.is_a?(Array) ? (0..a.size - 1).cover?(e) : a.key?(e)
           end
           a[e]
         end

--- a/lib/dry/validation/values.rb
+++ b/lib/dry/validation/values.rb
@@ -52,11 +52,16 @@ module Dry
       end
 
       # @api public
-      def key?(key)
-        return data.key?(key) if key.is_a?(Symbol)
+      def key?(key, hash = data)
+        return hash.key?(key) if key.is_a?(Symbol)
 
-        Schema::Path[key].reduce(data) do |a, e|
-          return false unless a.key?(e)
+        Schema::Path[key].reduce(hash) do |a, e|
+          if e.is_a?(Array)
+            result = e.all? { |k| key?(k, a) }
+            return result
+          else
+            return false unless a.key?(e)
+          end
           a[e]
         end
 

--- a/spec/integration/contract/call_spec.rb
+++ b/spec/integration/contract/call_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe Dry::Validation::Contract, '#call' do
         end
       end
 
+      rule(:login) do
+        if value?
+          key.failure('too short') if value.length < 3
+        end
+      end
+
+      rule(address: :geolocation) do
+        if value?
+          key.failure('not enough data') if value.size < 2
+        end
+      end
+
       rule(:password) do
         key.failure('is required') if values[:login] && !values[:password]
       end

--- a/spec/integration/contract/call_spec.rb
+++ b/spec/integration/contract/call_spec.rb
@@ -58,13 +58,8 @@ RSpec.describe Dry::Validation::Contract, '#call' do
         end
       end
 
-      rule(address: { geolocation: :lon }) do
-        address = values[:address]
-        geolocation = address[:geolocation] if address
-
-        if geolocation && !(-180.0...180.0).cover?(geolocation[:lon])
-          key.failure('invalid longitude')
-        end
+      rule('address.geolocation.lon') do
+        key.failure('invalid longitude') if value? && !(-180.0...180.0).cover?(value)
       end
     end.new
   end

--- a/spec/integration/contract/call_spec.rb
+++ b/spec/integration/contract/call_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe Dry::Validation::Contract, '#call' do
       end
 
       rule(:login) do
-        if value?
+        if key?
           key.failure('too short') if value.length < 3
         end
       end
 
       rule(address: { geolocation: [:lon, :lat] }) do
-        if value?
+        if key?
           lon, lat = value
           key('address.geolocation.lat').failure('invalid') if lat < 10
           key('address.geolocation.lon').failure('invalid') if lon < 10
@@ -59,7 +59,7 @@ RSpec.describe Dry::Validation::Contract, '#call' do
       end
 
       rule('address.geolocation.lon') do
-        key.failure('invalid longitude') if value? && !(-180.0...180.0).cover?(value)
+        key.failure('invalid longitude') if key? && !(-180.0...180.0).cover?(value)
       end
     end.new
   end

--- a/spec/integration/contract/call_spec.rb
+++ b/spec/integration/contract/call_spec.rb
@@ -33,8 +33,9 @@ RSpec.describe Dry::Validation::Contract, '#call' do
 
       rule(address: { geolocation: [:lon, :lat] }) do
         if value?
-          key('address.geolocation.lat').failure('invalid') if values['address.geolocation.lat'] < 10
-          key('address.geolocation.lon').failure('invalid') if values['address.geolocation.lon'] < 10
+          lon, lat = value
+          key('address.geolocation.lat').failure('invalid') if lat < 10
+          key('address.geolocation.lon').failure('invalid') if lon < 10
         end
       end
 

--- a/spec/unit/values_spec.rb
+++ b/spec/unit/values_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe Dry::Validation::Values do
       expect(values[address: :city]).to eql('Paris')
     end
 
+    it 'works with a hash pointing to multiple values' do
+      expect(values[address: { geo: [:lat, :lon] }]).to eql([1, 2])
+    end
+
     it 'works with an array' do
       expect(values[%i[address city]]).to eql('Paris')
     end

--- a/spec/unit/values_spec.rb
+++ b/spec/unit/values_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dry::Validation::Values do
   end
 
   let(:data) do
-    { name: 'Jane', address: { city: 'Paris', geo: { lat: 1, lon: 2 } } }
+    { name: 'Jane', address: { city: 'Paris', geo: { lat: 1, lon: 2 } }, phones: [123, 431] }
   end
 
   describe '#[]' do
@@ -65,8 +65,16 @@ RSpec.describe Dry::Validation::Values do
       expect(values.key?([:address, :geo, [:lat, :lon]])).to be(true)
     end
 
-    it 'returns true when nested keys are not all present' do
+    it 'returns false when nested keys are not all present' do
       expect(values.key?([:address, :geo, [:lat, :lon, :other]])).to be(false)
+    end
+
+    it 'returns true when a path to an array element is present' do
+      expect(values.key?([:phones, 1])).to be(true)
+    end
+
+    it 'returns false when a path to an array element is not present' do
+      expect(values.key?([:phones, 5])).to be(false)
     end
   end
 

--- a/spec/unit/values_spec.rb
+++ b/spec/unit/values_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dry::Validation::Values do
   end
 
   let(:data) do
-    { name: 'Jane', address: { city: 'Paris' } }
+    { name: 'Jane', address: { city: 'Paris', geo: { lat: 1, lon: 2 } } }
   end
 
   describe '#[]' do
@@ -55,6 +55,14 @@ RSpec.describe Dry::Validation::Values do
 
     it 'returns false when a nested key is not present' do
       expect(values.key?([:address, :not_here])).to be(false)
+    end
+
+    it 'returns true when nested keys are all present' do
+      expect(values.key?([:address, :geo, [:lat, :lon]])).to be(true)
+    end
+
+    it 'returns true when nested keys are not all present' do
+      expect(values.key?([:address, :geo, [:lat, :lon, :other]])).to be(false)
     end
   end
 

--- a/spec/unit/values_spec.rb
+++ b/spec/unit/values_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe Dry::Validation::Values do
     end
   end
 
+  describe '#key?' do
+    it 'returns true when a symbol key is present' do
+      expect(values.key?(:name)).to be(true)
+    end
+
+    it 'returns false when a symbol key is not present' do
+      expect(values.key?(:not_here)).to be(false)
+    end
+
+    it 'returns true when a nested key is present' do
+      expect(values.key?([:address, :city])).to be(true)
+    end
+
+    it 'returns false when a nested key is not present' do
+      expect(values.key?([:address, :not_here])).to be(false)
+    end
+  end
+
   describe '#dig' do
     it 'returns a value from a nested hash when it exists' do
       expect(values.dig(:address, :city)).to eql('Paris')


### PR DESCRIPTION
This is helpful when dealing with optional keys. We can't just assume
that we do not want to execute a rule when a value was missing.

Good example: a password must be provided when login is provided, and
both are optional.

Refs #540