### PR TITLE
Pass keyword arguments to `each` rule

### DIFF
--- a/lib/dry/validation/function.rb
+++ b/lib/dry/validation/function.rb
@@ -19,21 +19,24 @@ module Dry
       #   @api private
       option :block
 
+      # @!attribute [r] block_options
+      #   @return [Hash]
+      #   @api private
+      option :block_options, default: -> { block ? map_keywords(block) : EMPTY_HASH }
+
       private
 
       # Extract options for the block kwargs
       #
-      # @return [Hash]
+      # @param [Proc] block Callable
+      # @return Hash
       #
       # @api private
-      def block_options
-        return EMPTY_HASH unless block
-
-        @block_options ||= block
+      def map_keywords(block)
+        block
           .parameters
-          .select { |arg| arg[0].equal?(:keyreq) }
-          .map(&:last)
-          .map { |name| [name, BLOCK_OPTIONS_MAPPINGS[name]] }
+          .select { |arg,| arg.equal?(:keyreq) }
+          .map { |_, name| [name, BLOCK_OPTIONS_MAPPINGS[name]] }
           .to_h
       end
     end

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -93,6 +93,8 @@ module Dry
           end
         end
 
+        @block_options = map_keywords(block) if block
+
         self
       end
 

--- a/spec/integration/contract/class_interface/rule/each_spec.rb
+++ b/spec/integration/contract/class_interface/rule/each_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe Dry::Validation::Contract, 'Rule#each' do
         rule(hash: :another_nums).each do
           key.failure('invalid') if value < 3
         end
+
+        rule(:nums).each do |context:|
+          context[:sum] ||= 0
+          context[:sum] += value
+        end
       end
     end
 
@@ -37,6 +42,10 @@ RSpec.describe Dry::Validation::Contract, 'Rule#each' do
     it 'applies rule to nested values when an item passed schema checks' do
       expect(contract.(nums: [4], hash: { another_nums: ['oops', 1, 4] }).errors.to_h)
         .to eql(hash: { another_nums: { 0 => ['must be an integer'], 1 => ['invalid'] } })
+    end
+
+    it 'passes block options' do
+      expect(contract.(nums: [10, 20]).context[:sum]).to eql(30)
     end
   end
 


### PR DESCRIPTION
This also fixes uncached calls to `block.parameters` after calling `with`