### PR TITLE
Dry::Validation::Contract.schema to return defined schema

### DIFF
--- a/lib/dry/validation/contract/class_interface.rb
+++ b/lib/dry/validation/contract/class_interface.rb
@@ -53,7 +53,7 @@ module Dry
         #
         # This type of schema is suitable for HTTP parameters
         #
-        # @return [Dry::Schema::Params]
+        # @return [Dry::Schema::Params,NilClass]
         # @see https://dry-rb.org/gems/dry-schema/params/
         #
         # @api public
@@ -65,7 +65,7 @@ module Dry
         #
         # This type of schema is suitable for JSON data
         #
-        # @return [Dry::Schema::JSON]
+        # @return [Dry::Schema::JSON,NilClass]
         # @see https://dry-rb.org/gems/dry-schema/json/
         #
         # @api public
@@ -77,7 +77,7 @@ module Dry
         #
         # This type of schema does not offer coercion out of the box
         #
-        # @return [Dry::Schema::Processor]
+        # @return [Dry::Schema::Processor,NilClass]
         # @see https://dry-rb.org/gems/dry-schema/
         #
         # @api public
@@ -198,7 +198,9 @@ module Dry
 
         # @api private
         def define(method_name, &block)
-          if defined?(@__schema__)
+          return __schema__ if block.nil?
+
+          unless __schema__.nil?
             raise ::Dry::Validation::DuplicateSchemaError, 'Schema has already been defined'
           end
 

--- a/spec/integration/contract/class_interface/json_spec.rb
+++ b/spec/integration/contract/class_interface/json_spec.rb
@@ -12,7 +12,15 @@ RSpec.describe Dry::Validation::Contract, '.json' do
   end
 
   it 'defines a JSON schema' do
-    expect(contract_class.__schema__).to be_a(Dry::Schema::JSON)
+    expect(contract_class.schema).to be_a(Dry::Schema::JSON)
+    expect(contract_class.json).to be_a(Dry::Schema::JSON)
+
+    expect(contract_class.schema).to be(contract_class.json)
+  end
+
+  it 'returns nil if schema is not defined' do
+    contract_class = Class.new(Dry::Validation::Contract)
+    expect(contract_class.schema).to be(nil)
   end
 
   it 'raises an error if schema is already defined' do

--- a/spec/integration/contract/class_interface/params_spec.rb
+++ b/spec/integration/contract/class_interface/params_spec.rb
@@ -12,7 +12,15 @@ RSpec.describe Dry::Validation::Contract, '.params' do
   end
 
   it 'defines a Params schema' do
-    expect(contract_class.__schema__).to be_a(Dry::Schema::Params)
+    expect(contract_class.schema).to be_a(Dry::Schema::Params)
+    expect(contract_class.params).to be_a(Dry::Schema::Params)
+
+    expect(contract_class.schema).to be(contract_class.params)
+  end
+
+  it 'returns nil if schema is not defined' do
+    contract_class = Class.new(Dry::Validation::Contract)
+    expect(contract_class.schema).to be(nil)
   end
 
   it 'raises an error if schema is already defined' do

--- a/spec/integration/contract/class_interface/schema_spec.rb
+++ b/spec/integration/contract/class_interface/schema_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe Dry::Validation::Contract, '.schema' do
   end
 
   it 'defines a schema' do
-    expect(contract_class.__schema__).to be_a(Dry::Schema::Processor)
+    expect(contract_class.schema).to be_a(Dry::Schema::Processor)
+  end
+
+  it 'returns nil if schema is not defined' do
+    contract_class = Class.new(Dry::Validation::Contract)
+    expect(contract_class.schema).to be(nil)
   end
 
   it 'raises an error if schema is already defined' do


### PR DESCRIPTION
## Enhancement

Let `Dry::Validation::Contract.schema`, `.params`, and `.json` to return defined schema when invoked without block.

As per agreement with @solnic & @flash-gordon.

## Examples

### Empty schema

```ruby
class EmptyContract < Dry::Validation::Contract
end

EmptyContract.schema # => nil
```

### Getter

```ruby
class AddressContract < Dry::Validation::Contract
  schema do
    required(:city).value(:string)
  end
end

AddressContract.schema # => #<Dry::Schema::Processor keys=[:city] rules={:city=>"key?(:city) AND key[city](str?)"}>
```

### Aliases

```ruby
class TravelContract < Dry::Validation::Contract
  params do
    required(:destination).value(:string)
  end
end

TravelContract.schema # => #<Dry::Schema::Params keys=["destination"] rules={:destination=>"key?(:destination) AND key[destination](str?)"}>

TravelContract.params # => #<Dry::Schema::Params keys=["destination"] rules={:destination=>"key?(:destination) AND key[destination](str?)"}>
```

By the same extent `.json` works the same

### Double defined schema

This is an **already existing behavior**

```ruby
class DoubleContract < Dry::Validation::Contract
  schema { }
  schema { }
end

# => Dry::Validation::DuplicateSchemaError (Schema has already been defined)
```