### PR TITLE
Don't require block argument with external schema

### DIFF
--- a/lib/dry/validation/contract/class_interface.rb
+++ b/lib/dry/validation/contract/class_interface.rb
@@ -198,7 +198,7 @@ module Dry
 
         # @api private
         def define(method_name, external_schema, &block)
-          return __schema__ if block.nil?
+          return __schema__ if external_schema.nil? && block.nil?
 
           unless __schema__.nil?
             raise ::Dry::Validation::DuplicateSchemaError, 'Schema has already been defined'

--- a/spec/integration/contract/class_interface/schema_spec.rb
+++ b/spec/integration/contract/class_interface/schema_spec.rb
@@ -55,5 +55,17 @@ RSpec.describe Dry::Validation::Contract, '.schema' do
       expect(contract.(email: '', name: '').errors.to_h)
         .to eql(email: ['must be filled'], name: ['must be filled'])
     end
+
+    context 'schema without block argument' do
+      subject(:contract_class) do
+        Class.new(Dry::Validation::Contract) do
+          schema Test::UserSchema
+        end
+      end
+
+      it 'uses the external schema' do
+        expect(contract_class.schema).to be_a(Dry::Schema::Processor)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a small tweak to the feature added in #580, based on the feature request in #574 

If you are defining a schema externally, it makes sense that you won't always need to extend the schema inside the contract. This PR allows the following:

```ruby
class MySchema < Dry::Schema::Params
  # Schema DSL
end

class MyContract < Dry::Validation::Contract
  params MySchema.new
end
```