### PR TITLE
Multiple parent schemas

### DIFF
--- a/lib/dry/validation/contract/class_interface.rb
+++ b/lib/dry/validation/contract/class_interface.rb
@@ -57,8 +57,8 @@ module Dry
         # @see https://dry-rb.org/gems/dry-schema/params/
         #
         # @api public
-        def params(external_schema = nil, &block)
-          define(:Params, external_schema, &block)
+        def params(*external_schemas, &block)
+          define(:Params, external_schemas, &block)
         end
 
         # Define a JSON schema for your contract
@@ -69,8 +69,8 @@ module Dry
         # @see https://dry-rb.org/gems/dry-schema/json/
         #
         # @api public
-        def json(external_schema = nil, &block)
-          define(:JSON, external_schema, &block)
+        def json(*external_schemas, &block)
+          define(:JSON, external_schemas, &block)
         end
 
         # Define a plain schema for your contract
@@ -81,8 +81,8 @@ module Dry
         # @see https://dry-rb.org/gems/dry-schema/
         #
         # @api public
-        def schema(external_schema = nil, &block)
-          define(:schema, external_schema, &block)
+        def schema(*external_schemas, &block)
+          define(:schema, external_schemas, &block)
         end
 
         # Define a rule for your contract
@@ -197,8 +197,8 @@ module Dry
         end
 
         # @api private
-        def define(method_name, external_schema, &block)
-          return __schema__ if external_schema.nil? && block.nil?
+        def define(method_name, external_schemas, &block)
+          return __schema__ if external_schemas.empty? && block.nil?
 
           unless __schema__.nil?
             raise ::Dry::Validation::DuplicateSchemaError, 'Schema has already been defined'
@@ -206,7 +206,7 @@ module Dry
 
           schema_opts = core_schema_opts
 
-          schema_opts.update(parent: external_schema) if external_schema
+          schema_opts.update(parent: external_schemas) if external_schemas.any?
 
           case method_name
           when :schema

--- a/spec/integration/contract/class_interface/schema_spec.rb
+++ b/spec/integration/contract/class_interface/schema_spec.rb
@@ -67,5 +67,29 @@ RSpec.describe Dry::Validation::Contract, '.schema' do
         expect(contract_class.schema).to be_a(Dry::Schema::Processor)
       end
     end
+
+    context 'setting multiple external schemas' do
+      subject(:contract_class) do
+        Class.new(Dry::Validation::Contract) do
+          schema(Test::UserSchema, Test::CompanySchema) do
+            required(:name).filled(:string)
+          end
+        end
+      end
+
+      before do
+        Test::CompanySchema = Dry::Schema.Params do
+          required(:company).filled(:string)
+        end
+      end
+
+      it 'extends the schemas' do
+        contract = contract_class.new
+        expect(contract.(email: '', name: '', company: '').errors.to_h)
+          .to eql(email: ['must be filled'],
+                  name: ['must be filled'],
+                  company: ['must be filled'])
+      end
+    end
   end
 end

--- a/spec/integration/contract/using_messages_spec.rb
+++ b/spec/integration/contract/using_messages_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Dry::Validation::Contract do
         end
 
         rule(:email) do
-          value = values[:email]
           key.failure(:invalid) unless value.include?('@')
           key.failure(:taken, values.to_h) if value == 'jane@doe.org'
         end


### PR DESCRIPTION
This allows dry-validation to make use of the multiple parent feature in dry-schema (https://github.com/dry-rb/dry-schema/pull/191)

This is a BC change, the schema/params/json methods now take one or more parent schemas as an argument