### PR TITLE
Bug fix: MessageSet caches empty? too early

### DIFF
--- a/lib/dry/validation/message_set.rb
+++ b/lib/dry/validation/message_set.rb
@@ -54,6 +54,7 @@ module Dry
       #
       # @api private
       def add(message)
+        @empty = nil
         source_messages << message
         messages << message
         initialize_placeholders!

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe Dry::Validation::Result do
         expect(errors[nil]).to eql(['root error'])
       end
     end
+
+    describe '#empty?' do
+      let(:result) { Dry::Validation::Result.new(params) }
+
+      it 'should return the correct value whilst adding errors' do
+        expect(result.errors).to be_empty
+        result.add_error(Dry::Validation::Message.new('root error', path: [nil]))
+        expect(result.errors).not_to be_empty
+      end
+    end
   end
 
   describe '#inspect' do


### PR DESCRIPTION
MessageSet in Dry::Validation allows for the set to be manipulated after init.  Its superclass attempts to cache the result of computing #empty? by setting the @empty ivar.

Because of this #empty? will always return true if it is called prior to #add_error.

This pull request fixes that bug by setting @empty to nil when #add_error is called.