### PR TITLE
Replace map flatten with flat_map

### DIFF
--- a/lib/dry/validation/contract/class_interface.rb
+++ b/lib/dry/validation/contract/class_interface.rb
@@ -162,7 +162,7 @@ module Dry
             .map { |key|
               [key, Schema::Path[key]]
             }
-            .map { |(key, path)|
+            .flat_map { |(key, path)|
               if (last = path.last).is_a?(Array)
                 last.map { |last_key|
                   path_key = [*path.to_a[0..-2], last_key]
@@ -172,7 +172,6 @@ module Dry
                 [[key, path]]
               end
             }
-            .flatten(1)
             .reject { |(_, path)|
               valid_paths.any? { |valid_path| valid_path.include?(path) }
             }

--- a/lib/dry/validation/schema_ext.rb
+++ b/lib/dry/validation/schema_ext.rb
@@ -30,7 +30,7 @@ module Dry
       class Hash < Key
         # @api private
         def to_dot_notation
-          [name].product(members.map(&:to_dot_notation).flatten(1)).map { |e| e.join(DOT) }
+          [name].product(members.flat_map(&:to_dot_notation)).map { |e| e.join(DOT) }
         end
       end
     end


### PR DESCRIPTION
# Replace map flatten with flat_map

Using `flat_map` over `map.flatten` is 1.6 faster according to [Enumerable#map...Array#flatten vs Enumerable#flat_map](https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code).
Failing specs are unrelated i.e. they also fail on `master` branch.