### PR TITLE
Add an explicit error when failure is configured with an invalid hash

### DIFF
--- a/lib/dry/validation/failures.rb
+++ b/lib/dry/validation/failures.rb
@@ -45,6 +45,13 @@ module Dry
       #   @example
       #     failure(:taken)
       #
+      # @overload failure(meta_hash)
+      #   Use meta_hash[:text] as a message (either explicitely or as an identifier),
+      #   setting the rest of the hash as error meta attribute
+      #   @param meta [Hash] The hash containing the message as value for the :text key
+      #   @example
+      #     failure({text: :invalid, key: value})
+      #
       # @see Evaluator#key
       # @see Evaluator#base
       #

--- a/lib/dry/validation/messages/resolver.rb
+++ b/lib/dry/validation/messages/resolver.rb
@@ -22,6 +22,8 @@ module Dry
         # Resolve Message object from provided args and path
         #
         # This is used internally by contracts when rules are applied
+        # If message argument is a Hash, then it MUST have a :text key,
+        # which value will be used as the message value
         #
         # @return [Message, Message::Localized]
         #
@@ -34,7 +36,12 @@ module Dry
             Message[message, path, meta]
           when Hash
             meta = message.dup
-            text = meta.delete(:text)
+            text = meta.delete(:text) { |key|
+              raise ArgumentError, <<~STR
+                +message+ Hash must contain :#{key} key (#{message.inspect} given)
+              STR
+            }
+
             call(message: text, tokens: tokens, path: path, meta: meta)
           else
             raise ArgumentError, <<~STR

--- a/spec/integration/contract/evaluator/failure_spec.rb
+++ b/spec/integration/contract/evaluator/failure_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe Dry::Validation::Evaluator do
       expect(errors.to_h).to eql(email: [text: 'is invalid', code: 102])
       expect(errors.first.meta).to eql(code: 102)
     end
+
+    context 'without :text key' do
+      before do
+        contract_class.rule(:email) do
+          key.failure(code: 102)
+        end
+      end
+
+      it 'raises argument error if no text key provided' do
+        expect { contract.(email: 'foo').errors }.to raise_error(ArgumentError, /Hash must contain :text key/)
+      end
+    end
   end
 
   context 'when localized message id is invalid' do

--- a/spec/integration/contract/evaluator/failure_spec.rb
+++ b/spec/integration/contract/evaluator/failure_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe Dry::Validation::Evaluator do
       end
 
       it 'raises argument error if no text key provided' do
-        expect { contract.(email: 'foo').errors }.to raise_error(ArgumentError, /Hash must contain :text key/)
+        expect {
+          contract.(email: 'foo').errors
+        }.to raise_error(ArgumentError, /Hash must contain :text key/)
       end
     end
   end


### PR DESCRIPTION
as discussed here: https://github.com/dry-rb/dry-validation/issues/584

