### PR TITLE
Draft PR: Composable contracts 

### DIFF
--- a/lib/dry/validation.rb
+++ b/lib/dry/validation.rb
@@ -27,6 +27,10 @@ module Dry
       require 'dry/validation/extensions/predicates_as_macros'
     end
 
+    register_extension(:composable) do
+      require 'dry/validation/extensions/composable'
+    end
+
     # Define a contract and build its instance
     #
     # @example

--- a/lib/dry/validation/composition.rb
+++ b/lib/dry/validation/composition.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'dry/validation/composition/step'
+
+module Dry
+  module Validation
+    # A Composition is a list of steps
+    #
+    # @see Dry::Validation::Composable
+    #
+    # @api private
+    class Composition
+      include Dry::Equalizer(:steps, inspect: false)
+
+      # @return [Array]
+      #
+      # @api private
+      attr_reader :steps
+
+      # @param [Array] initial steps array
+      def initialize(steps = EMPTY_ARRAY)
+        @steps = steps.dup
+      end
+
+      def inspect
+        steps_str = steps.map do |s|
+          s.prefix ? "#{s.prefix.to_a.join(DOT)} => #{s.contract}" : s.contract
+        end.join(', ')
+
+        "#<#{self.class.name} steps=[#{steps_str}]>"
+      end
+
+      # @return [Bool]
+      #
+      # @api private
+      def empty?
+        steps.empty?
+      end
+
+      # apply our steps to the input recording in result
+      #
+      # @param [Composition::Result]
+      # @param [Hash]
+      #
+      # @return [Composition::Result]
+      #
+      # @api private
+      def call(input, result = Composition::Result.new)
+        steps.reduce(result) { |final_result, step| step.call(input, final_result) }
+      end
+
+      # add a new step to the composition
+      #
+      # @param [Contract]
+      # @param [Schema::Path] optional
+      #
+      # @api private
+      def add_step(contract, prefix)
+        steps << Step.new(contract, prefix)
+        self
+      end
+    end
+  end
+end

--- a/lib/dry/validation/composition/builder.rb
+++ b/lib/dry/validation/composition/builder.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'dry/schema/path'
+
+module Dry
+  module Validation
+    class Composition
+      # Adds steps to a composition via #contract and #path methods
+      #
+      # @api private
+      class Builder
+        # @return [Composition]
+        #
+        # @api private
+        attr_reader :composition
+
+        # @return [Schema::Path]
+        #
+        # @api private
+        attr_reader :prefix
+
+        def initialize(composition, prefix = nil)
+          @composition = composition
+          @prefix = Schema::Path[prefix] if prefix
+        end
+
+        def contract(contract, path: nil)
+          composition.add_step contract, prefixed(path)
+        end
+
+        def path(path, &block)
+          self.class.new(composition, prefixed(path)).instance_eval(&block)
+        end
+
+        private
+
+        def prefixed(path)
+          path = Schema::Path[path] if path
+          path = Schema::Path.new([*prefix, *path]) if prefix
+          path
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/validation/composition/result.rb
+++ b/lib/dry/validation/composition/result.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'dry/validation/result_interface'
+
+module Dry
+  module Validation
+    class Composition
+      # A Composition::Result is built from many results with optional
+      # input prefixes.
+      #
+      # @see ResultInterface
+      #
+      # @api public
+      class Result
+        include ResultInterface
+
+        include Dry::Equalizer(:errors, :values, inspect: false)
+
+        # Build a new result
+        #
+        # @param [Dry::Schema::Result] schema_result
+        #
+        # @api private
+        def self.new(options = EMPTY_HASH)
+          result = super
+          yield(result) if block_given?
+          result.freeze
+        end
+
+        # Result options
+        #
+        # @return [Hash]
+        #
+        # @api private
+        attr_reader :options
+
+        # Result values
+        #
+        # @return [Values]
+        #
+        # @api public
+        attr_reader :values
+
+        # prefixed results
+        #
+        # @return [Array[Schema::Path, Result]]
+        #
+        # @api private
+        attr_reader :prefixed_results
+
+        # Initialize a new result
+        #
+        # @api private
+        def initialize(options)
+          @options = options
+          @values  = Values.new({})
+          @errors  = MessageSet.new([], options)
+
+          # prefixed results is only necessary so that we can rebuild error
+          # messages when passed options to #errors.
+          #
+          # TODO: can we see a way of having a MessageSet be able to rebuild
+          #       itself given new options?
+          @prefixed_results = []
+        end
+
+        # Freeze values and errors
+        #
+        # @api private
+        def freeze
+          values.freeze
+          errors.freeze
+          @prefixed_results.freeze
+          super
+        end
+
+        # Add a result, merging its values, and adding its errors, optionally prefixed
+        #
+        # @api private
+        def add_result(result, prefix = nil)
+          add_values(result.to_h, prefix)
+          prefixed_results << [prefix, result]
+          @errors = build_errors(options)
+          self
+        end
+
+        # Get error set
+        #
+        # @!macro errors-options
+        #   @param [Hash] new_options
+        #   @option new_options [Symbol] :locale Set locale for messages
+        #   @option new_options [Boolean] :hints Enable/disable hints
+        #   @option new_options [Boolean] :full Get messages that include key names
+        #
+        # @return [MessageSet]
+        #
+        # @api public
+        def errors(new_options = EMPTY_HASH)
+          new_options.empty? ? @errors : build_errors(new_options)
+        end
+
+        private
+
+        # merge the supplied hash into our values
+        #
+        # @api private
+        def add_values(hash, prefix)
+          hash = prefixed_hash(hash, prefix) if prefix
+          @values = Values.new(merge_hashes(@values.to_h, hash))
+        end
+
+        # build the errors from scratch using the supplied options
+        #
+        # @api private
+        def build_errors(options)
+          empty_set = MessageSet.new([], options)
+          prefixed_results.each_with_object(empty_set) do |(prefix, result), errors|
+            result.errors(options).each do |error|
+              path = prefix ? Schema::Path[prefix].to_a + error.path : error.path
+              errors.add Message[error.text, path, error.meta]
+            end
+          end
+        end
+
+        # prefix the passed hash input with the given path prefix
+        #
+        # @example
+        #   prefixed_hash({foo: 1}, 'bar.baz') # => { bar: { baz: { foo: 1 } } }
+        #
+        # @api private
+        def prefixed_hash(input, prefix)
+          prefix = Schema::Path[prefix].to_a
+          output = prefix.reverse.reduce({}) { |m, key| { key => m } }
+          output.dig(*prefix).merge!(input)
+          output
+        end
+
+        # merge hashes, merging values only in the case of a conflict where both are hash
+        #
+        # @example
+        #
+        #   l = { a: { b: 1 }, d: [1] }
+        #   r = { a: { c: 2 }, d: [2] }
+        #
+        #   merge_hashes(l, r) # => { a: { b: 1, c: 2 }, d: [2] }
+        #
+        # @api private
+        def merge_hashes(left, right)
+          left.merge(right) do |_key, left_val, right_val|
+            if left_val.is_a?(Hash) && right_val.is_a?(Hash)
+              merge_hashes(left_val, right_val)
+            else
+              right_val
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/validation/composition/step.rb
+++ b/lib/dry/validation/composition/step.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Dry
+  module Validation
+    class Composition
+      # A composition step consists of a contract optionally at a prefix
+      #
+      # @api private
+      class Step
+        include Dry::Equalizer(:contract, :prefix, inspect: false)
+
+        # @return [Contract]
+        #
+        # @api private
+        attr_reader :contract
+
+        # @return [Schema::Path]
+        #
+        # @api private
+        attr_reader :prefix
+
+        def initialize(contract, prefix = nil)
+          @contract = contract
+          @prefix = prefix
+        end
+
+        # call contract (at prefix) on the input and add it to the result
+        #
+        # @param [Composition::Result]
+        # @param [Hash]
+        #
+        # @return [Composition::Result]
+        #
+        # @api private
+        def call(input, result = Composition::Result)
+          input = input.dig(*prefix) if prefix
+          contract_instance = contract.respond_to?(:call) ? contract : contract.new
+          result.add_result(contract_instance.call(input), prefix)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/validation/extensions/composable.rb
+++ b/lib/dry/validation/extensions/composable.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'dry/validation/contract'
+require 'dry/validation/composition'
+require 'dry/validation/composition/builder'
+require 'dry/validation/composition/result'
+
+module Dry
+  module Validation
+    # Extension to allow contracts to be composed of other contracts
+    #
+    # Current limitations
+    #   - no support for sharing context between contracts
+    #   - no way of specifying a contract for each element of array input
+    #   - no way of conditionally applying a contract to the input
+    #
+    # @example
+    #   Dry::Validation.load_extensions(:composable)
+    #
+    #   class PlayerContract < Dry::Validation::Contract
+    #     schema do
+    #       required(:name).filled(:string)
+    #       required(:age).filled(:integer)
+    #     end
+    #
+    #     rule(:age).validate(gteq?: 18)
+    #   end
+    #
+    #   class CaptainContract < Dry::Validation::Contract
+    #     schema do
+    #       required(:became_captain_on).filled(:date)
+    #     end
+    #
+    #     contract PlayerContract
+    #   end
+    #
+    # @api public
+    module Composable
+      module ContractExtensions
+        def self.prepended(contract)
+          contract.class_eval do
+            extend ClassInterface
+
+            # we allow contracts with no schemas if they have a composition
+            #
+            # @!attribute [r] schema
+            #   @return [Dry::Schema::Params, Dry::Schema::JSON, Dry::Schema::Processor]
+            #   @api private
+            option :schema, default: -> { self.class.__schema__ }
+
+            # @!attribute [r] composition
+            #   @return [Composition]
+            #   @api private
+            option :composition, default: -> { default_composition }
+
+            # add composition to equalizer
+            include Dry::Equalizer(:schema, :rules, :messages, :composition, inspect: false)
+          end
+        end
+
+        # Apply the contract to an input including any composition
+        #
+        # @param [Hash] input The input to validate
+        #
+        # @return [Result,Composition::Result]
+        #
+        # @api public
+        def call(input)
+          return contract_result(input) if composition.empty?
+
+          Composition::Result.new do |result|
+            composition.call(input, result)
+            result.add_result contract_result(input) if schema
+          end
+        end
+
+        # Return a nice string representation
+        #
+        # @return [String]
+        #
+        # @api public
+        def inspect
+          parts = []
+          parts << "schema=#{schema.inspect}" << "rules=#{rules.inspect}" if schema
+          parts << "composition=#{composition.inspect}" unless composition.empty?
+
+          "#<#{self.class} #{parts.join(' ')}>"
+        end
+
+        private
+
+        def default_composition
+          self.class.composition
+        ensure
+          raise SchemaMissingError, self.class if self.class.composition.empty? && !schema
+        end
+
+        module ClassInterface
+          # declare that the passed contract should be applied to the input,
+          # optionally at the specified path
+          #
+          # @example
+          #   contract CustomerContract
+          #
+          # @example using a path
+          #   contract AddressContract, path: :address
+          #
+          # @api public
+          def contract(contract, path: nil)
+            composition_builder.contract(contract, path: path)
+          end
+
+          # scope enclosed contracts to the specified path
+          #
+          # @example
+          #   path :address do
+          #     contract AddressContract
+          #
+          #     path :location do
+          #       contract GeoLocation
+          #     end
+          #   end
+          #
+          # @api public
+          def path(path, &block)
+            composition_builder.path(path, &block)
+          end
+
+          # @return [Composition]
+          #
+          # @api private
+          def composition
+            @composition ||= begin
+              steps = superclass.respond_to?(:composition) ? superclass.composition.steps : []
+              Composition.new(steps)
+            end
+          end
+
+          # @return [Composition::Builder]
+          #
+          # @api private
+          def composition_builder
+            @composition_builder ||= Composition::Builder.new(composition)
+          end
+        end
+      end
+
+      Contract.prepend(ContractExtensions)
+    end
+  end
+end

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -6,13 +6,18 @@ require 'dry/equalizer'
 require 'dry/validation/constants'
 require 'dry/validation/message_set'
 require 'dry/validation/values'
+require 'dry/validation/result_interface'
 
 module Dry
   module Validation
     # Result objects are returned by contracts
     #
+    # @see ResultInterface
+    #
     # @api public
     class Result
+      include ResultInterface
+
       include Dry::Equalizer(:schema_result, :context, :errors, inspect: false)
 
       # Build a new result
@@ -81,24 +86,6 @@ module Dry
         new_options.empty? ? @errors : @errors.with(schema_errors(new_options), new_options)
       end
 
-      # Check if result is successful
-      #
-      # @return [Bool]
-      #
-      # @api public
-      def success?
-        @errors.empty?
-      end
-
-      # Check if result is not successful
-      #
-      # @return [Bool]
-      #
-      # @api public
-      def failure?
-        !success?
-      end
-
       # Check if values include an error for the provided key
       #
       # @api private
@@ -128,46 +115,6 @@ module Dry
       def add_error(error)
         @errors.add(error)
         self
-      end
-
-      # Read a value under provided key
-      #
-      # @param [Symbol] key
-      #
-      # @return [Object]
-      #
-      # @api public
-      def [](key)
-        values[key]
-      end
-
-      # Check if a key was set
-      #
-      # @param [Symbol] key
-      #
-      # @return [Bool]
-      #
-      # @api public
-      def key?(key)
-        values.key?(key)
-      end
-
-      # Coerce to a hash
-      #
-      # @api public
-      def to_h
-        values.to_h
-      end
-
-      # Return a string representation
-      #
-      # @api public
-      def inspect
-        if context.empty?
-          "#<#{self.class}#{to_h} errors=#{errors.to_h}>"
-        else
-          "#<#{self.class}#{to_h} errors=#{errors.to_h} context=#{context.each.to_h}>"
-        end
       end
 
       # Freeze result and its error set

--- a/lib/dry/validation/result_interface.rb
+++ b/lib/dry/validation/result_interface.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Dry
+  module Validation
+    # Result interface for objects returned by Contract#call
+    #
+    # Implementors must define #values and #errors
+    module ResultInterface
+      # The values of this result
+      #
+      # @return [Values]
+      #
+      # @api public
+      def values
+        raise NotImplementedError, "implement #values to return #{Values}"
+      end
+
+      # The errors of this result
+      #
+      # @return [MessageSet]
+      #
+      # @api public
+      def errors
+        raise NotImplementedError, "implement #errors to return #{MessageSet}"
+      end
+
+      # Check if result is successful
+      #
+      # @return [Bool]
+      #
+      # @api public
+      def success?
+        errors.empty?
+      end
+
+      # Check if result is not successful
+      #
+      # @return [Bool]
+      #
+      # @api public
+      def failure?
+        !success?
+      end
+
+      # Read a value under provided key
+      #
+      # @param [Symbol] key
+      #
+      # @return [Object]
+      #
+      # @api public
+      def [](key)
+        values[key]
+      end
+
+      # Check if a key was set
+      #
+      # @param [Symbol] key
+      #
+      # @return [Bool]
+      #
+      # @api public
+      def key?(key)
+        values.key?(key)
+      end
+
+      # Coerce to a hash
+      #
+      # @api public
+      def to_h
+        values.to_h
+      end
+
+      # Return a string representation
+      #
+      # @api public
+      def inspect
+        if context.empty?
+          "#<#{self.class}#{to_h} errors=#{errors.to_h}>"
+        else
+          "#<#{self.class}#{to_h} errors=#{errors.to_h} context=#{context.each.to_h}>"
+        end
+      end
+    end
+  end
+end

--- a/spec/extensions/composable/contract_spec.rb
+++ b/spec/extensions/composable/contract_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'dry/validation/extensions/composable'
+
+RSpec.describe Dry::Validation::Contract do
+  context 'with composable extension' do
+    before { Dry::Validation.load_extensions(:composable) }
+
+    subject(:contract) { contract_class.new }
+
+    before do
+      class Test::EmailContract < Dry::Validation::Contract
+        params { required(:email).value(:string, format?: /@/) }
+      end
+
+      class Test::NameContract < Dry::Validation::Contract
+        params { required(:name).filled(:string) }
+      end
+    end
+
+    describe 'composed of two contracts' do
+      let(:contract_class) do
+        class Test::ComposedContract < Dry::Validation::Contract
+          contract Test::EmailContract
+          contract Test::NameContract
+        end
+
+        Test::ComposedContract
+      end
+
+      it 'has a composition for the two contracts' do
+        expected = Dry::Validation::Composition.new
+          .add_step(Test::EmailContract, nil)
+          .add_step(Test::NameContract, nil)
+
+        expect(contract_class.composition).to eq(expected)
+      end
+
+      it 'has a nice string representation' do
+        composition_str = contract.composition.inspect
+        expect(contract.inspect)
+          .to eql("#<Test::ComposedContract composition=#{composition_str}>")
+      end
+
+      describe '#call(input)' do
+        subject(:result) { contract.call(input) }
+
+        let(:input) { { email: 'foo', name: 'jim', other: 'foo' } }
+
+        it 'returns a result' do
+          expect(subject).to be_failure
+        end
+
+        it 'has appropriate values' do
+          expect(result.to_h).to eq(email: 'foo', name: 'jim')
+        end
+
+        it 'has appropriate errors' do
+          expect(result.errors.to_h).to eq(email: ['is in invalid format'])
+        end
+      end
+    end
+
+    describe 'own schema/rules and composed of contract' do
+      let(:contract_class) do
+        class Test::ComposedContract < Dry::Validation::Contract
+          contract Test::EmailContract
+          contract Test::NameContract
+
+          params do
+            required(:phone).value(:string, format?: /\d+/)
+          end
+
+          rule(:phone) do
+            emergency = /^000|999|911|01189998819991197253$/
+            key.failure('is emergency services') if value =~ emergency
+          end
+        end
+
+        Test::ComposedContract
+      end
+
+      describe '#call(input)' do
+        subject(:result) { contract.call(input) }
+
+        let(:input) do
+          { email: 'moss#reynholm.com',
+            name: 'Moss',
+            phone: '01189998819991197253' }
+        end
+
+        it 'returns a result' do
+          expect(subject).to be_failure
+        end
+
+        it 'has appropriate values' do
+          expect(result.to_h).to eq(email: 'moss#reynholm.com',
+                                    name: 'Moss',
+                                    phone: '01189998819991197253')
+        end
+
+        it 'has appropriate errors' do
+          expect(result.errors.to_h).to eq(email: ['is in invalid format'],
+                                           phone: ['is emergency services'])
+        end
+      end
+    end
+
+    describe 'composed of multiple (composed) contracts at different paths' do
+      before do
+        class Test::PersonContract < Dry::Validation::Contract
+          contract Test::EmailContract
+          contract Test::NameContract
+        end
+      end
+
+      let(:contract_class) do
+        class Test::ComposedContract < Dry::Validation::Contract
+          contract Test::PersonContract
+
+          path :emergency do
+            contract Test::PersonContract
+
+            path :backup do
+              contract Test::PersonContract
+            end
+          end
+        end
+
+        Test::ComposedContract
+      end
+
+      describe '#call(input)' do
+        subject(:result) { contract.call(input) }
+
+        let(:input) do
+          { email: 'foo',
+            name: '',
+            shmemergency: { noise: 'XXXXXX' },
+            emergency: { name: 'smudger',
+                         whoops: 'why is this here?',
+                         backup: { email: 'ok@email.com',
+                                   name: '' } } }
+        end
+
+        it 'returns a result' do
+          expect(subject).to be_failure
+        end
+
+        it 'has appropriate values at the specified paths' do
+          expect(result.to_h).to eq(email: 'foo',
+                                    name: '',
+                                    emergency: { name: 'smudger',
+                                                 backup: { email: 'ok@email.com',
+                                                           name: '' } })
+        end
+
+        it 'has errors from all contracts at the specified paths' do
+          expect(result.errors.to_h)
+            .to eq(email: ['is in invalid format'],
+                   name: ['must be filled'],
+                   emergency: { email: ['is missing'],
+                                backup: { name: ['must be filled'] } })
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/composition/builder_spec.rb
+++ b/spec/integration/composition/builder_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'dry/validation/composition'
+require 'dry/validation/composition/builder'
+
+RSpec.describe Dry::Validation::Composition::Builder do
+  let(:step) { Dry::Validation::Composition::Step }
+  let(:path) { Dry::Schema::Path }
+
+  before do
+    class Test::Contract < Dry::Validation::Contract
+      schema { required(:email).filled(:string) }
+    end
+  end
+
+  subject(:builder) { Dry::Validation::Composition::Builder.new(composition) }
+
+  let(:composition) { Dry::Validation::Composition.new }
+
+  describe '#contract' do
+    it '(Contract) adds a step for the contract to the composition' do
+      builder.contract Test::Contract
+      expect(composition.steps[0]).to eq step.new(Test::Contract, nil)
+    end
+
+    it '(Contract, path:) adds a step for the contract at that path' do
+      builder.contract Test::Contract, path: 'foo.bar'
+      expect(composition.steps[0]).to eq step.new(Test::Contract, path.new([:foo, :bar]))
+    end
+  end
+
+  describe '#path("foo.bar") { ... }' do
+    before { builder.path('foo.bar', &block) }
+
+    let(:block) { proc { contract Test::Contract } }
+
+    it 'scopes the contracts in the block to that path' do
+      expect(composition.steps[0]).to eq step.new(Test::Contract, path.new([:foo, :bar]))
+    end
+
+    describe 'with nested blocks and paths specified' do
+      let(:block) do
+        proc do
+          contract Test::Contract
+          path :baz do
+            contract Test::Contract
+            contract Test::Contract, path: 'bang'
+          end
+        end
+      end
+
+      it 'adds steps with the correct prefixes' do
+        expect(composition.steps).to eq([
+          step.new(Test::Contract, path['foo.bar']),
+          step.new(Test::Contract, path['foo.bar.baz']),
+          step.new(Test::Contract, path['foo.bar.baz.bang'])
+        ])
+      end
+    end
+  end
+end

--- a/spec/integration/composition/result_spec.rb
+++ b/spec/integration/composition/result_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'dry/validation/composition/result'
+
+RSpec.describe Dry::Validation::Composition::Result do
+  subject(:result) do
+    Dry::Validation::Composition::Result.new do |result|
+      results.each { |r| result.add_result(r) }
+    end
+  end
+
+  let(:results) { [] }
+
+  let(:email_schema) do
+    Dry::Schema.define { required(:email).value(:string, format?: /@/) }
+  end
+
+  let(:name_contract) do
+    Dry::Validation.Contract do
+      params { required(:name).filled(:string) }
+
+      rule(:name) { base.failure('You must be Jim') if value != 'Jim' }
+    end
+  end
+
+  context 'with no results' do
+    it { is_expected.to be_success }
+
+    it '#to_h returns an empty hash' do
+      expect(result.to_h).to eq({})
+    end
+  end
+
+  context 'with 2 successful results' do
+    let(:results) do
+      [email_schema.(email: 'foo@bar'), name_contract.(name: 'Jim')]
+    end
+
+    it { is_expected.to be_success }
+
+    it '#to_h has the values from both results' do
+      expect(result.to_h).to eq(email: 'foo@bar', name: 'Jim')
+    end
+  end
+
+  context '1 successful result, 1 failure result' do
+    let(:results) do
+      [email_schema.(email: 'fred@email.com'), name_contract.(name: 'Fred')]
+    end
+
+    it { is_expected.to be_failure }
+
+    it '#to_h has the values from both results' do
+      expect(result.to_h).to eq(email: 'fred@email.com', name: 'Fred')
+    end
+
+    it 'has the errors from the failure' do
+      expect(result.errors.to_h).to eq(nil => ['You must be Jim'])
+      expect(result.errors(full: true).map(&:to_s)).to eq ['You must be Jim']
+    end
+  end
+
+  context '2 failure results' do
+    let(:results) do
+      [email_schema.(email: 'nope'), name_contract.(name: 'Jade')]
+    end
+
+    it { is_expected.to be_failure }
+
+    it '#to_h has the values from both results' do
+      expect(result.to_h).to eq(email: 'nope', name: 'Jade')
+    end
+
+    it 'has the errors from the failures' do
+      expect(result.errors(full: true).map(&:to_s))
+        .to eq ['email is in invalid format', 'You must be Jim']
+
+      expect(result.errors.to_h).to eq(email: ['is in invalid format'],
+                                       nil => ['You must be Jim'])
+    end
+  end
+
+  context 'multiple failure results for the same key' do
+    let(:name_length_schema) do
+      Dry::Schema.define { required(:name).value(:string, min_size?: 3) }
+    end
+
+    let(:results) do
+      [name_contract.(name: ''), name_length_schema.(name: '')]
+    end
+
+    it 'concatenates the errors at the key' do
+      expect(result.errors.to_h).to eq(name: ['must be filled', 'size cannot be less than 3'])
+    end
+  end
+
+  context 'results at different paths' do
+    subject(:result) do
+      Dry::Validation::Composition::Result.new do |result|
+        result.add_result email_schema.(email: 'smudger')
+        result.add_result email_schema.(email: 'paino'), :keeper
+        result.add_result email_schema.(email: 'gary'), 'leg.fine'
+        result.add_result email_schema.(email: 'cummins'), [:leg, :square, :deep]
+      end
+    end
+
+    it '#to_h has values at the specified paths' do
+      expect(result.to_h)
+        .to eq(email: 'smudger',
+               keeper: { email: 'paino' },
+               leg: { fine: { email: 'gary' },
+                      square: { deep: { email: 'cummins' } } })
+    end
+
+    it '#errors has messages at the specified paths' do
+      expect(result.errors.to_h)
+        .to eq(email: ['is in invalid format'],
+               keeper: { email: ['is in invalid format'] },
+               leg: { fine: { email: ['is in invalid format'] },
+                      square: { deep: { email: ['is in invalid format'] } } })
+    end
+  end
+end

--- a/spec/integration/composition_spec.rb
+++ b/spec/integration/composition_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'dry/validation/composition'
+
+RSpec.describe Dry::Validation::Composition do
+  let(:step) { Dry::Validation::Composition::Step }
+  let(:path) { Dry::Schema::Path }
+
+  subject(:composition) { Dry::Validation::Composition.new(steps) }
+
+  before do
+    class Test::Contract < Dry::Validation::Contract
+      schema { required(:email).filled(:string) }
+    end
+  end
+
+  describe 'with no steps' do
+    let(:steps) { [] }
+
+    it '#call returns a succesful Composition::Result' do
+      expect(subject.call({})).to be_success
+    end
+  end
+
+  describe 'with steps' do
+    let(:steps) { [step.new(Test::Contract, nil)] }
+
+    it 'has a nice string representation' do
+      expect(composition.inspect)
+        .to eq '#<Dry::Validation::Composition steps=[Test::Contract]>'
+    end
+
+    describe '#add_step(contract, Schema::Path["foo"])' do
+      before { composition.add_step(Test::Contract, path['foo']) }
+
+      it 'adds to the composition steps' do
+        expect(composition.steps).to eq([
+          step.new(Test::Contract, nil),
+          step.new(Test::Contract, path['foo'])
+        ])
+      end
+
+      it 'does not mutate the original steps' do
+        expect(steps).to eq [step.new(Test::Contract, nil)]
+      end
+
+      it 'has a nice string representation' do
+        expect(composition.inspect).to include(
+          'steps=[Test::Contract, foo => Test::Contract]>'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello! This is a draft PR, in order to get early feedback, as suggested by @solnic.

I've suggested some questions which I think I'd ask, and given my answers.  I'd love to get feedback, of any sort.

### What is it?

An extension for dry-rb that enables contracts to be composed of other contracts.

It looks like this:

```ruby
Dry::Validation.load_extensions(:composable)

class OrderContract < Dry::Validation::Contract
  contract CustomerContract
  path :address do
    contract AddressContract
  end
end
```

### What did you change?

I did some minor refactoring to `contract.rb`, and extracted an interface from `result.rb` (with no functional changes according to the tests) to make my life easier and reduce duplicated code.

I added a bunch of code in `composition.rb` and `composition/*` and hooked that code into Contract via the extension mechanism.

### What problem does it solve?

For me, it solves two problems.

1. reusing contracts, including their rules
2. applying contracts to nested hashes of the input, without having to write the rules such that they know about their position in the tree.

### What does it not do yet?

Current limitations that I can see are

- no support for sharing context between contracts
- no way of specifying a contract for each element of **array** input
- no way of conditionally applying a contract to the input
- specific interaction with other extensions is not well tested

### Anything else?

Nope, thanks for your time!

