### PR TITLE
Fix error messages path sorting

### DIFF
--- a/lib/dry/validation/message_set.rb
+++ b/lib/dry/validation/message_set.rb
@@ -115,7 +115,7 @@ module Dry
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/PerceivedComplexity
       def initialize_placeholders!
-        @placeholders = unique_paths.each_with_object(EMPTY_HASH.dup) { |path, hash|
+        @placeholders = unique_paths.sort_by(&:size).each_with_object(EMPTY_HASH.dup) { |path, hash|
           curr_idx = 0
           last_idx = path.size - 1
           node = hash


### PR DESCRIPTION
This PR solves the problem with a path intersection.

Currently, the longest path can be processed a first and made this a `Hash`, instead of `Array`. 

Solution: sort paths by size.

If you need a spec, please tell me where I should place it, because currently, I do not understand where I should place this case.

Example:

```rb
require 'dry/validation'

class MyForm < Dry::Validation::Contract
  params do
    required(:rules).each do
      schema do
        required(:domains).each(:str?)
      end
    end
  end

  rule(:rules).each do
    key(path.keys + [:domains]).failure('Failed')
    key.failure('Failed')
  end
end

puts MyForm.new.call(rules: [{domains: ['some']}]).errors.to_h
```

Expected:

```rb
{:rules=>{0=>[["Failed"], {:domains=>["Failed"]}]}}
```

Got:

```
Traceback (most recent call last):
	10: from dry-v.rb:18:in `<main>'
	 9: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-validation-1.3.1/lib/dry/validation/contract.rb:94:in `call'
	 8: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-validation-1.3.1/lib/dry/validation/result.rb:26:in `new'
	 7: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-validation-1.3.1/lib/dry/validation/result.rb:178:in `freeze'
	 6: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-validation-1.3.1/lib/dry/validation/message_set.rb:92:in `freeze'
	 5: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-schema-1.4.1/lib/dry/schema/message_set.rb:67:in `to_h'
	 4: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-validation-1.3.1/lib/dry/validation/message_set.rb:105:in `messages_map'
	 3: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-validation-1.3.1/lib/dry/validation/message_set.rb:105:in `reduce'
	 2: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-schema-1.4.1/lib/dry/schema/message_set.rb:58:in `each'
	 1: from /Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-schema-1.4.1/lib/dry/schema/message_set.rb:58:in `each'
/Users/bugagazavr/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/dry-validation-1.3.1/lib/dry/validation/message_set.rb:107:in `block in messages_map': undefined method `<<' for {:domains=>["Failed"]}:Hash (NoMethodError)
Did you mean? <
```

Workaround:

Change rules order

```rb
  rule(:rules).each do
    key.failure('Failed')
    key(path.keys + [:domains]).failure('Failed')
  end
```