### PR TITLE
Optimize the performance of `MessageSet#with`

### DIFF
--- a/lib/dry/validation/message_set.rb
+++ b/lib/dry/validation/message_set.rb
@@ -41,7 +41,7 @@ module Dry
         return self if new_options.empty? && other.eql?(messages)
 
         self.class.new(
-          (other + select { |err| err.is_a?(Message) }).uniq,
+          other | select { |err| err.is_a?(Message) },
           options.merge(source: source_messages, **new_options)
         ).freeze
       end


### PR DESCRIPTION
This pull request makes `Dry::Validation::MessageSet#with` implementation a little bit more more efficient.

The idea behind the pull request is that for any two arrays `a` and `b`,  `a | b` is functionally equivalent to `(a + b).uniq`, but it is faster because it doesn't allocate an intermediate array. 

Artificial benchmarks:

```ruby
require 'benchmark/ips'

[
  [:small,
    [:a, :b],
    [:b, :c, :b]
  ],

  [:both_empty,
    [],
    []
  ],

  [:left_empty,
    [],
    [:b, :c, :c, :e]
  ],

  [:right_empty,
    [:b, :c, :d, :b],
    []
  ],

  [:huge,
    Array.new(1000) { rand(100) },
    Array.new(1000) { rand(100) }
 ]
].each do |type, other, this|
  fail 'boom' unless (other + this).uniq == other | this

  puts "=== #{type} ==="
  Benchmark.ips do |x|
    x.report('+.uniq') { (other + this).uniq }
    x.report('|') { other | this }
    x.compare!
  end
end

__END__

=== small ===
Warming up --------------------------------------
              +.uniq   182.055k i/100ms
                   |   243.087k i/100ms
Calculating -------------------------------------
              +.uniq      3.429M (± 4.5%) i/s -     17.113M in   5.001905s
                   |      5.603M (± 3.8%) i/s -     28.198M in   5.040012s

Comparison:
                   |:  5603159.3 i/s
              +.uniq:  3428681.5 i/s - 1.63x  slower

=== both_empty ===
Warming up --------------------------------------
              +.uniq   266.196k i/100ms
                   |   303.531k i/100ms
Calculating -------------------------------------
              +.uniq      6.873M (± 3.8%) i/s -     34.339M in   5.004125s
                   |      9.951M (± 3.5%) i/s -     49.779M in   5.008667s

Comparison:
                   |:  9950986.7 i/s
              +.uniq:  6872603.7 i/s - 1.45x  slower

=== left_empty ===
Warming up --------------------------------------
              +.uniq   191.744k i/100ms
                   |   255.101k i/100ms
Calculating -------------------------------------
              +.uniq      3.565M (± 4.6%) i/s -     17.832M in   5.013313s
                   |      6.156M (± 4.2%) i/s -     30.867M in   5.023715s

Comparison:
                   |:  6156059.7 i/s
              +.uniq:  3565042.0 i/s - 1.73x  slower

=== right_empty ===
Warming up --------------------------------------
              +.uniq   190.313k i/100ms
                   |   258.484k i/100ms
Calculating -------------------------------------
              +.uniq      3.581M (± 5.6%) i/s -     17.889M in   5.011803s
                   |      6.592M (± 3.6%) i/s -     33.086M in   5.025788s

Comparison:
                   |:  6591933.7 i/s
              +.uniq:  3581433.5 i/s - 1.84x  slower

=== huge ===
Warming up --------------------------------------
              +.uniq     2.009k i/100ms
                   |     2.559k i/100ms
Calculating -------------------------------------
              +.uniq     21.151k (±11.3%) i/s -    106.477k in   5.141076s
                   |     25.838k (± 3.9%) i/s -    130.509k in   5.059123s

Comparison:
                   |:    25837.9 i/s
              +.uniq:    21151.2 i/s - 1.22x  slower
```