### PR TITLE
Add support for pattern matching on result values

### DIFF
--- a/.github/workflows/custom_ci.yml
+++ b/.github/workflows/custom_ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "2.6", "2.5", "2.4", "jruby"]
+        ruby: ["2.7", "2.6", "2.5", "2.4"]
         include:
           - ruby: "2.7"
             dry_schema_from_master: "true"

--- a/.github/workflows/custom_ci.yml
+++ b/.github/workflows/custom_ci.yml
@@ -18,9 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.7", "2.6", "2.5", "2.4", "jruby"]
-        dry_schema_from_master: ["false", "true"]
-        dry_types_from_master: ["false", "true"]
         include:
+          - ruby: "2.7"
+            dry_schema_from_master: "true"
+            dry_types_from_master: "true"
+            coverage: "false"
           - ruby: "2.7"
             dry_schema_from_master: "false"
             dry_types_from_master: "false"

--- a/.github/workflows/custom_ci.yml
+++ b/.github/workflows/custom_ci.yml
@@ -17,11 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.6", "2.5", "2.4"]
+        ruby: ["2.7", "2.6", "2.5", "2.4", "jruby"]
         dry_schema_from_master: ["false", "true"]
         dry_types_from_master: ["false", "true"]
         include:
-          - ruby: "2.6"
+          - ruby: "2.7"
             dry_schema_from_master: "false"
             dry_types_from_master: "false"
             coverage: "true"

--- a/.github/workflows/custom_ci.yml
+++ b/.github/workflows/custom_ci.yml
@@ -22,10 +22,6 @@ jobs:
           - ruby: "2.7"
             dry_schema_from_master: "true"
             dry_types_from_master: "true"
-            coverage: "false"
-          - ruby: "2.7"
-            dry_schema_from_master: "false"
-            dry_types_from_master: "false"
             coverage: "true"
     steps:
       - uses: actions/checkout@v1

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,11 @@ eval_gemfile 'Gemfile.devtools'
 
 gemspec
 
-if ENV['USE_SCHEMA_MASTER'].eql?('true')
+if ENV['DRY_SCHEMA_FROM_MASTER'].eql?('true')
   gem 'dry-schema', github: 'dry-rb/dry-schema', branch: 'master'
 end
 
-if ENV['USE_TYPES_MASTER'].eql?('true')
+if ENV['DRY_TYPES_FROM_MASTER'].eql?('true')
   gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'
 end
 

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -12,6 +12,7 @@ sections:
   - macros
   - external-dependencies
   - extensions
+  - pattern-matching
 ---
 
 dry-validation is a data validation library that provides a powerful DSL for defining schemas and validation rules.
@@ -31,7 +32,7 @@ There are a couple of unique features that make `dry-validation` stand out from 
 
 Here's an example contract:
 
-``` ruby
+```ruby
 class NewUserContract < Dry::Validation::Contract
   params do
     required(:email).filled(:string)

--- a/docsite/source/pattern-matching.html.md
+++ b/docsite/source/pattern-matching.html.md
@@ -1,0 +1,96 @@
+---
+title: Pattern matching
+layout: gem-single
+name: dry-validation
+---
+
+Ruby 2.7 added experimental support for pattern matching. dry-validation supports pattern matching on result values starting with 1.4.1.
+
+```ruby
+class PersonContract < Dry::Validation::Contract
+  params do
+    required(:first_name).filled
+    required(:last_name).filled
+  end
+end
+
+contract = PersonContract.new
+
+case contract.('first_name' => 'John', 'last_name' => 'Doe')
+in { first_name:, last_name: } => result if result.success?
+  puts "Hello #{first_name} #{last_name}"
+in _ => result
+  puts "Invalid input: #{result.errors.to_h}"
+end
+```
+
+Alternatively, results can be matched as a 2-value tuple of two hashes. The hash is validation output as in the previous example. The second is the context value shared between rules.
+
+```ruby
+class AddressContract < Dry::Validation::Contract
+  option :address_repo
+
+  params do
+    required(:address).filled
+  end
+
+  rule(:address) do |context:|
+    address = address_repo.find(value)
+    contex[:address] = address if address
+  end
+end
+
+contract = AddressContract.new(address_repo: AddressRepo.new)
+
+case contract.('name' => 'John Doe', 'address' => 'Pedro Moreno 10, Ciudad de México')
+in [{ name: }, { address: }] => result if result.success?
+  # adding person to existing address
+in { name:, address: } => result if result.success?
+  # adding person to new address
+else
+  # showing errors
+end
+```
+
+### Pattern matching with monads
+
+It may get tedious to write `if result.success?` every time. Another option is using the `:monads` extention that wraps `Result` objects with `Success`/`Failure` constructors.
+
+```ruby
+require 'dry/validation'
+require 'dry/monads'
+
+Dry::Validation.load_extensions(:monads)
+
+class CreatePerson
+  include Dry::Monads[:result]
+
+  class Contract < Dry::Validation::Contract
+    params do
+      required(:first_name).filled
+      required(:last_name).filled
+    end
+  end
+
+  attr_reader :repo
+
+  def initialize(repo)
+    @repo = repo
+  end
+
+  def call(input)
+    case contract.(input).to_monad
+    in Success(first_name:, last_name:)
+      Success(repo.create(first_name, last_name))
+    in Failure(result)
+      Failure(result.errors.to_h)
+    end
+  end
+
+  def contract
+    @contract ||= Contract.new
+  end
+end
+```
+
+In this example it is important to have monads included in the class with `include Dry::Monads[:result]` because of how pattern matching works in Ruby. Still, it's neat!

--- a/dry-validation.gemspec
+++ b/dry-validation.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
   spec.add_runtime_dependency 'dry-container', '~> 0.7', '>= 0.7.1'
   spec.add_runtime_dependency 'dry-initializer', '~> 3.0'
-  spec.add_runtime_dependency 'dry-schema', '~> 1.0', '>= 1.3.1'
+  spec.add_runtime_dependency 'dry-schema', '~> 1.0', '>= 1.4.3'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -179,6 +179,22 @@ module Dry
         super
       end
 
+      if RUBY_VERSION >= '2.7'
+        # Pattern matching
+        #
+        # @api private
+        def deconstruct_keys(keys)
+          values.deconstruct_keys(keys)
+        end
+
+        # Pattern matching
+        #
+        # @api private
+        def deconstruct
+          [values, context.each.to_h]
+        end
+      end
+
       private
 
       # @api private

--- a/spec/integration/result/pattern_matching_spec.rb
+++ b/spec/integration/result/pattern_matching_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Validation::Result do
+  let(:params) do
+    double(:params, message_set: [], to_h: { email: 'jane@doe.org' })
+  end
+
+  let(:success) do
+    Dry::Validation::Result.new(params, context)
+  end
+
+  let(:context) do
+    context = Concurrent::Map.new
+    context[:country] = 'Sweden'
+    context
+  end
+
+  it 'supports pattern matching with keys' do
+    case success
+    in email:
+      expect(email).to eql('jane@doe.org')
+    end
+  end
+
+  it 'supports pattern matching with arrays extracting keys and context'  do
+    case success
+    in [{ email: }, { country: }]
+      expect(email).to eql('jane@doe.org')
+      expect(country).to eql('Sweden')
+    end
+  end
+
+  context 'with monads' do
+    before { Dry::Validation.load_extensions(:monads) }
+
+    example 'success' do
+      case success.to_monad
+      in Dry::Monads::Result::Success(email:)
+        expect(email).to eql('jane@doe.org')
+      end
+
+      case success.to_monad
+      in Dry::Monads::Result::Success([_, { country: }])
+        expect(country).to eql('Sweden')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,25 +14,20 @@ require 'dry/validation'
 
 SPEC_ROOT = Pathname(__dir__)
 
-Dir[SPEC_ROOT.join('shared/**/*.rb')].each(&method(:require))
 Dir[SPEC_ROOT.join('support/**/*.rb')].each(&method(:require))
 
 RSpec.configure do |config|
+  unless RUBY_VERSION >= '2.7'
+    config.exclude_pattern = '**/pattern_matching_spec.rb'
+  end
+
   config.disable_monkey_patching!
-  config.warnings = true
 
   config.before do
-    module Test
-      def self.remove_constants
-        constants.each { |const| remove_const(const) }
-        self
-      end
-    end
+    stub_const('Test', Module.new)
   end
 
   config.after do
-    Object.send(:remove_const, Test.remove_constants.name)
-
     I18n.load_path = [Dry::Schema::DEFAULT_MESSAGES_PATH]
     I18n.locale = :en
     I18n.reload!


### PR DESCRIPTION
Two possible ways of matching a result:

1. With keys
```ruby
case contract_result
in foo:, bar: 'baz'
  # same as in dry-schema
end
```

2. With arrays (tuple, pair of hash values)
```ruby
case contract_result
in { value_from_input: }, { context_value: }
  # rules can add values to context that after can be destructured like above
end
```