### PR TITLE
Change top_namespace type to String instead of Symbol

### DIFF
--- a/docsite/source/configuration.html.md
+++ b/docsite/source/configuration.html.md
@@ -52,7 +52,7 @@ If you want your contract classes to use `my_app` as your own top-level namespac
 
 ``` ruby
 class ApplicationContract < Dry::Validation::Contract
-  config.messages.top_namespace = :my_app
+  config.messages.top_namespace = 'my_app'
   config.messages.load_paths << 'config/errors.yml'
 end
 ```


### PR DESCRIPTION
It has to be a String 'cause if not you'll have an error:

```ruby
TypeError:
  no implicit conversion of Symbol into String
# .../dry-schema-1.4.3/lib/dry/schema/messages/yaml.rb:139:in `gsub'
```