### PR TITLE
Update Resolver to the new messages API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,7 @@ if ENV['DRY_CONFIGURABLE_FROM_MASTER'].eql?('true')
   gem 'dry-configurable', github: 'dry-rb/dry-configurable', branch: 'master'
 end
 
-if ENV['DRY_SCHEMA_FROM_MASTER'].eql?('true')
-  gem 'dry-schema', github: 'dry-rb/dry-schema', branch: 'master'
-end
+gem 'dry-schema', github: 'dry-rb/dry-schema', branch: 'master'
 
 if ENV['DRY_TYPES_FROM_MASTER'].eql?('true')
   gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'


### PR DESCRIPTION
After dry-rb/dry-schema#233 the `Messages::Abstract#[]` API changed and it now returns a hash with `text` and `meta` already populated, because text evaluation is now handled by the backend (which is a really good thing).

This PR simply updates internals to work with the changed `#[]` API.