### PR TITLE
Remove old MessageSet to_h code

### DIFF
--- a/lib/dry/validation/message_set.rb
+++ b/lib/dry/validation/message_set.rb
@@ -57,7 +57,6 @@ module Dry
         @empty = nil
         source_messages << message
         messages << message
-        initialize_placeholders!
         self
       end
 
@@ -93,51 +92,6 @@ module Dry
         to_h
         self
       end
-
-      private
-
-      # @api private
-      def unique_paths
-        source_messages.uniq(&:path).map(&:path)
-      end
-
-      # @api private
-      def messages_map
-        @messages_map ||= reduce(placeholders) { |hash, msg|
-          node = msg.path.reduce(hash) { |a, e| a.is_a?(Hash) ? a[e] : a.last[e] }
-          (node[0].is_a?(::Array) ? node[0] : node) << msg.dump
-          hash
-        }
-      end
-
-      # @api private
-      #
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/PerceivedComplexity
-      def initialize_placeholders!
-        @placeholders = unique_paths.sort_by(&:size).each_with_object(EMPTY_HASH.dup) { |path, hash|
-          curr_idx = 0
-          last_idx = path.size - 1
-          node = hash
-
-          while curr_idx <= last_idx
-            key = path[curr_idx]
-
-            next_node =
-              if node.is_a?(Array) && key.is_a?(Symbol)
-                node_hash = (node << [] << {}).last
-                node_hash[key] || (node_hash[key] = curr_idx < last_idx ? {} : [])
-              else
-                node[key] || (node[key] = curr_idx < last_idx ? {} : [])
-              end
-
-            node = next_node
-            curr_idx += 1
-          end
-        }
-      end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/PerceivedComplexity
     end
   end
 end


### PR DESCRIPTION
This code is no longer needed due to https://github.com/dry-rb/dry-schema/pull/248, but needs https://github.com/dry-rb/dry-schema/pull/250 to land before it passes CI.