### PR TITLE
Revert "Update Resolver to the new messages API"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,9 @@ if ENV['DRY_CONFIGURABLE_FROM_MASTER'].eql?('true')
   gem 'dry-configurable', github: 'dry-rb/dry-configurable', branch: 'master'
 end
 
-gem 'dry-schema', github: 'dry-rb/dry-schema', branch: 'master'
+if ENV['DRY_SCHEMA_FROM_MASTER'].eql?('true')
+  gem 'dry-schema', github: 'dry-rb/dry-schema', branch: 'master'
+end
 
 if ENV['DRY_TYPES_FROM_MASTER'].eql?('true')
   gem 'dry-types', github: 'dry-rb/dry-types', branch: 'master'

--- a/lib/dry/validation/messages/resolver.rb
+++ b/lib/dry/validation/messages/resolver.rb
@@ -62,25 +62,23 @@ module Dry
           keys = path.to_a.compact
           msg_opts = tokens.merge(path: keys, locale: locale || messages.default_locale)
 
-          options = msg_opts.merge(parse_tokens(tokens))
+          if keys.empty?
+            template, meta = messages["rules.#{rule}", msg_opts]
+          else
+            template, meta = messages[rule, msg_opts.merge(path: keys.join(DOT))]
+            template, meta = messages[rule, msg_opts.merge(path: keys.last)] unless template
+          end
 
-          message =
-            if keys.empty?
-              messages["rules.#{rule}", options]
-            else
-              messages[rule, options.merge(path: keys.join(DOT))] ||
-                messages[rule, options.merge(path: keys.last)]
-            end
-
-          unless message
+          unless template
             raise MissingMessageError, <<~STR
               Message template for #{rule.inspect} under #{keys.join(DOT).inspect} was not found
             STR
           end
 
-          text, meta = message.values_at(:text, :meta)
+          parsed_tokens = parse_tokens(tokens)
+          text = template.(template.data(parsed_tokens))
 
-          [full ? "#{messages.rule(keys.last, options)} #{text}" : text, meta]
+          [full ? "#{messages.rule(keys.last, msg_opts)} #{text}" : text, meta]
         end
         # rubocop:enable Metrics/AbcSize
 


### PR DESCRIPTION
Reverts dry-rb/dry-validation#626.

Will fail until dry-schema's template API is restored.