### PR TITLE
doc: YARD annotations with more documentation

### DIFF
--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -146,7 +146,7 @@ module Dry
       #
       # @return [Object]
       #
-      # @public
+      # @api public
       def value
         values[key_name]
       end
@@ -169,7 +169,7 @@ module Dry
 
       # Check if there are any errors on the schema under the provided path
       #
-      # @param [Symbol, String, Array] A Path-compatible spec
+      # @param path [Symbol, String, Array] A Path-compatible spec
       #
       # @return [Boolean]
       #

--- a/lib/dry/validation/macros.rb
+++ b/lib/dry/validation/macros.rb
@@ -25,7 +25,7 @@ module Dry
         #   end
         #
         # @param [Symbol] name The name of the macro
-        # @param [Array] *args Optional default arguments for the macro
+        # @param [Array] args Optional default positional arguments for the macro
         #
         # @return [self]
         #

--- a/lib/dry/validation/values.rb
+++ b/lib/dry/validation/values.rb
@@ -35,7 +35,10 @@ module Dry
       #     key.failure('must be > 18') if values[:age] <= 18
       #   end
       #
-      # @param [Symbol] key
+      # @param args [Symbol, String, Hash, Array<Symbol>] If given as a single
+      #   Symbol, String, Array or Hash, build a key array using
+      #   {Dry::Schema::Path} digging for data. If given as positional
+      #   arguments, use these with Hash#dig on the data directly.
       #
       # @return [Object]
       #


### PR DESCRIPTION
  -  an attempt to reduce warnings and still keep the documentation legible

## Background

Before this change, there were a few warnings when generating documentation.

> Building YARD (yri) index for dry-validation-1.5.0...
lib/dry/validation/macros.rb:28: [UnknownParam] @param tag has unknown parameter name: *args. Did you mean `args`?
lib/dry/validation/values.rb:38: [UnknownParam] @param tag has unknown parameter name: key
lib/dry/validation/evaluator.rb:149: [UnknownTag] Unknown tag @public
lib/dry/validation/evaluator.rb:172: [UnknownParam] @param tag has unknown parameter name: A

## Questions for reviewer

- Are there technical terms for the Schema::Path-compatible argument I tried to document, which was called "key"?