### PR TITLE
Don't require dry-monads in hints extension.

### DIFF
--- a/lib/dry/validation/extensions/hints.rb
+++ b/lib/dry/validation/extensions/hints.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "dry/monads/result"
-
 module Dry
   module Validation
     # Hints extension


### PR DESCRIPTION
It is not needed here and leads to an error when not using dry-monads