### PR TITLE
Typo: remove 'latter'

### DIFF
--- a/docsite/source/schemas.html.md
+++ b/docsite/source/schemas.html.md
@@ -47,7 +47,7 @@ class NewUserContract < Dry::Validation::Contract
 end
 ```
 
-The major difference between `params` and the plain `schema` is that `params` latter will perform params-specific coercions before applying the contract's rules. For example, it will coerce strings into integers:
+The major difference between `params` and the plain `schema` is that `params` will perform params-specific coercions before applying the contract's rules. For example, it will coerce strings into integers:
 
 ``` ruby
 result = contract.call('email' => 'jane@doe.org', 'age' => '21')


### PR DESCRIPTION
This sentence doesn't make sense with this word included. Maybe it used to say 'the latter'' in a previous version of the text, but even then the sentence reads clearly without it.

The 'Edit on github' link and GH's in-browser editing makes these changes easy to propose :)