### PR TITLE
Fix example output for returned data types

### DIFF
--- a/docsite/source/schemas.html.md
+++ b/docsite/source/schemas.html.md
@@ -77,7 +77,7 @@ result = contract.call('email' => 'jane@doe.org', 'age' => '21')
 # => #<Dry::Validation::Result{:email=>"jane@doe.org", :age=>"21"} errors={:age=>["must be an integer"]}>
 
 result = contract.call('email' => 'jane@doe.org', 'age' => 21)
-# => #<Dry::Validation::Result{:email=>"jane@doe.org", :age=>"21"} errors={}>
+# => #<Dry::Validation::Result{:email=>"jane@doe.org", :age=>21} errors={}>
 
 result.to_h
 # => {:email=>"jane@doe.org", :age=>21}
@@ -110,8 +110,10 @@ end
 
 contract = NewUserContract.new
 
-contract.(name: "Jane", age: "31", email: "jane@doe.org", country: "foo")# #<Dry::Validation::Result{:name=>"Jane", :age=>31, :email=>"jane@doe.org",
-#   :country=>"foo"} errors={:zipcode=>["is missing"], :street=>["is missing"],#   :mobile=>["is missing"]}>
+contract.(name: "Jane", age: "31", email: "jane@doe.org", country: "foo")
+# => #<Dry::Validation::Result{:name=>"Jane", :age=>31, :email=>"jane@doe.org",
+#   :country=>"foo"} errors={:zipcode=>["is missing"], :street=>["is missing"],
+#   :mobile=>["is missing"]}>
 ```
 
 The coercion logic is different to `params`. For example, since JSON natively supports integers, it will not coerce them from strings:
@@ -121,7 +123,7 @@ result = contract.call('email' => 'jane@doe.org', 'age' => '21')
 # => #<Dry::Validation::Result{:email=>"jane@doe.org", :age=>"21"} errors={:age=>["must be an integer"]}>
 
 result = contract.call('email' => 'jane@doe.org', 'age' => 21)
-# => #<Dry::Validation::Result{:email=>"jane@doe.org", :age=>"21"} errors={}>
+# => #<Dry::Validation::Result{:email=>"jane@doe.org", :age=>21} errors={}>
 
 result.to_h
 # => {:email=>"jane@doe.org", :age=>21}


### PR DESCRIPTION
- With the JSON examples where an integer was passed in as an argument, the example output formatted these as strings incorrectly
- One example of the Params schema passed in a `"31"` string and the example output kept it as a string, but when running the code it is converted to an integer `31` which matches a previous explanation
- Fix multi-line formatting of one of the examples