### PR TITLE
Fix key? predicate when path points to a non-existent array value

### DIFF
--- a/lib/dry/validation/values.rb
+++ b/lib/dry/validation/values.rb
@@ -68,6 +68,8 @@ module Dry
           if e.is_a?(Array)
             result = e.all? { |k| key?(k, a) }
             return result
+          elsif e.is_a?(Symbol) && a.is_a?(Array)
+            return false
           else
             return false unless a.is_a?(Array) ? (e >= 0 && e < a.size) : a.key?(e)
           end

--- a/spec/unit/values_spec.rb
+++ b/spec/unit/values_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe Dry::Validation::Values do
     it "returns false when a path to an array element is not present" do
       expect(values.key?([:phones, 5])).to be(false)
     end
+
+    it "returns false when a path to an array is a symbol as its last segment" do
+      expect(values.key?([:phones, :foo])).to be(false)
+    end
   end
 
   describe "#dig" do


### PR DESCRIPTION
Fixes #653