### PR TITLE
Make Result#error?(key) return true for rule and schema errors

### DIFF
--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -123,14 +123,14 @@ module Dry
           return path.expand.any? { |nested_path| error?(result, nested_path) }
         end
 
-        return true if result.error?(path)
+        return true if result.schema_error?(path)
 
         path
           .to_a[0..-2]
           .any? { |key|
             curr_path = Schema::Path[path.keys[0..path.keys.index(key)]]
 
-            return false unless result.error?(curr_path)
+            return false unless result.schema_error?(curr_path)
 
             result.errors.any? { |err|
               (other = Schema::Path[err.path]).same_root?(curr_path) && other == curr_path

--- a/lib/dry/validation/evaluator.rb
+++ b/lib/dry/validation/evaluator.rb
@@ -175,7 +175,7 @@ module Dry
       #
       # @api public
       def schema_error?(path)
-        result.error?(path)
+        result.schema_error?(path)
       end
 
       # Check if there are any errors on the current rule

--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -101,8 +101,15 @@ module Dry
 
       # Check if values include an error for the provided key
       #
-      # @api private
+      # @api public
       def error?(key)
+        errors.any? { |msg| Schema::Path[msg.path].include?(Schema::Path[key]) }
+      end
+
+      # Check if the base schema (without rules) includes an error for the provided key
+      #
+      # @api private
+      def schema_error?(key)
         schema_result.error?(key)
       end
 

--- a/lib/dry/validation/rule.rb
+++ b/lib/dry/validation/rule.rb
@@ -86,7 +86,7 @@ module Dry
             values[root].each_with_index do |_, idx|
               path = [*Schema::Path[root].to_a, idx]
 
-              next if result.error?(path)
+              next if result.schema_error?(path)
 
               evaluator = with(macros: macros, keys: [path], &block)
 

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -50,6 +50,33 @@ RSpec.describe Dry::Validation::Result do
     end
   end
 
+  describe "#error?" do
+    subject { result }
+
+    let(:schema_result) do
+      double(:schema_result, message_set: [], to_h: {email: "jane@doe.org"})
+    end
+
+    let(:result) do
+      Dry::Validation::Result.new(schema_result) do |r|
+        r.add_error(Dry::Validation::Message.new("root error", path: [nil]))
+        r.add_error(Dry::Validation::Message.new("email error", path: [:email]))
+      end
+    end
+
+    it "reports an error on email" do
+      expect(subject.error?(:email)).to eq true
+    end
+
+    it "reports an error on 'root' when asked for [nil]" do
+      expect(subject.error?([nil])).to eq true
+    end
+
+    it "doesn't report errors on non existing keys" do
+      expect(subject.error?(:nonexistant)).to eq false
+    end
+  end
+
   describe "#inspect" do
     let(:params) do
       double(:params, message_set: [], to_h: {})

--- a/spec/integration/result_spec.rb
+++ b/spec/integration/result_spec.rb
@@ -51,8 +51,6 @@ RSpec.describe Dry::Validation::Result do
   end
 
   describe "#error?" do
-    subject { result }
-
     let(:schema_result) do
       double(:schema_result, message_set: [], to_h: {email: "jane@doe.org"})
     end
@@ -65,15 +63,15 @@ RSpec.describe Dry::Validation::Result do
     end
 
     it "reports an error on email" do
-      expect(subject.error?(:email)).to eq true
+      expect(result.error?(:email)).to be(true)
     end
 
-    it "reports an error on 'root' when asked for [nil]" do
-      expect(subject.error?([nil])).to eq true
+    it "reports an error on 'root' when asked for nil" do
+      expect(result.error?([nil])).to be(true)
     end
 
     it "doesn't report errors on non existing keys" do
-      expect(subject.error?(:nonexistant)).to eq false
+      expect(result.error?(:nonexistant)).to be(false)
     end
   end
 


### PR DESCRIPTION
Not super happy with this as of now :) Exchanged usage of
error? with schema_error? in the code base as otherwise there
thankfully were a bunch of failures.

The implementation of error? itself is basically stolen from
its counterpart at `Schema::Result`. It makes sense to check
if there are any errors for this but not sure if we shouldn't
rather still call out to schema_result.error?

Also, root/base behavior is a bit of a mystery.

Fix attempt for #655 