### PR TITLE
Support per-key custom errors for array paths

### DIFF
--- a/lib/dry/validation/messages/resolver.rb
+++ b/lib/dry/validation/messages/resolver.rb
@@ -69,6 +69,11 @@ module Dry
             template, meta = messages[rule, msg_opts.merge(path: keys.last)] unless template
           end
 
+          if !template && keys.size > 1
+            non_index_keys = keys.reject { |k| k.is_a?(Integer) }
+            template, meta = messages[rule, msg_opts.merge(path: non_index_keys.join(DOT))]
+          end
+
           unless template
             raise MissingMessageError, <<~STR
               Message template for #{rule.inspect} under #{keys.join(DOT).inspect} was not found

--- a/spec/fixtures/messages/errors.en.yml
+++ b/spec/fixtures/messages/errors.en.yml
@@ -17,3 +17,5 @@ en:
           wrong: "not right"
         age:
           toddler: "should be included in %{list}"
+        small_integers:
+          too_big: "is too big!"

--- a/spec/integration/contract/class_interface/rule/each_spec.rb
+++ b/spec/integration/contract/class_interface/rule/each_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Dry::Validation::Contract, "Rule#each" do
 
         params do
           required(:nums).array(:integer)
+          optional(:small_integers).array(:integer)
           optional(:hash).hash do
             optional(:another_nums).array(:integer)
           end
@@ -21,6 +22,10 @@ RSpec.describe Dry::Validation::Contract, "Rule#each" do
 
         rule(:nums).each do
           key.failure("invalid") if value < 3
+        end
+
+        rule(:small_integers).each do
+          key.failure(:too_big) if value > 9
         end
 
         rule(hash: :another_nums).each do
@@ -50,6 +55,14 @@ RSpec.describe Dry::Validation::Contract, "Rule#each" do
 
     it "passes block options" do
       expect(contract.(nums: [10, 20]).context[:sum]).to eql(30)
+    end
+
+    it "returns error from the rule namespace without an index" do
+      contract_class.config.messages.load_paths << SPEC_ROOT.join("fixtures/messages/errors.en.yml").realpath
+      expect(contract.(small_integers: [11, 12], nums: [1]).errors.to_h)
+          .to eql(small_integers: { 0 => ["is too big!"],
+                                    1 => ["is too big!"]},
+                  nums: { 0 => ["invalid"] })
     end
   end
 


### PR DESCRIPTION
Resolves #663

This allows using custom errors by a key without an index when used in .each.
I guess there should be a better way to check if this is related to .each than by checking the keys array size, let me know if you have any ideas.