### PR TITLE
Set right dry-schema version

### DIFF
--- a/dry-validation.gemspec
+++ b/dry-validation.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-core", "~> 0.4"
   spec.add_runtime_dependency "dry-equalizer", "~> 0.2"
   spec.add_runtime_dependency "dry-initializer", "~> 3.0"
-  spec.add_runtime_dependency "dry-schema", "~> 1.5"
+  spec.add_runtime_dependency "dry-schema", "~> 1.5", ">= 1.5.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Last version `1.5.4` using the constant https://github.com/dry-rb/dry-validation/blob/master/lib/dry/validation/messages/resolver.rb#L9 from `dry-schema` which was introduced in version `1.5.2` https://github.com/dry-rb/dry-schema/blob/v1.5.2/lib/dry/schema/message_compiler.rb#L32

This patch fix `load_missing_constant` if project freeze gem versions and we update only dry-validation

Gemfile
```
gem "dry-schema", "1.5.0"
gem 'dry-validation', '1.5.4'
```

```
/usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/active_support.rb:79:in `block in load_missing_constant': uninitialized constant Dry::Schema::MessageCompiler::FULL_MESSAGE_WHITESPACE (Name
Error)
        from /usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/active_support.rb:8:in `without_bootsnap_cache'
        from /usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/active_support.rb:79:in `rescue in load_missing_constant'
        from /usr/local/bundle/gems/bootsnap-1.4.5/lib/bootsnap/load_path_cache/core_ext/active_support.rb:58:in `load_missing_constant'
        from /usr/local/bundle/gems/dry-validation-1.5.4/lib/dry/validation/messages/resolver.rb:9:in `<module:Messages>'
```
