### PR TITLE
Fix a typo in the dry-validation rules page

### DIFF
--- a/docsite/source/rules.html.md
+++ b/docsite/source/rules.html.md
@@ -294,7 +294,7 @@ contract.call({user_id: 42}, user: user).context.each.to_h
 # => {user: #<User id: 42>}
 ```
 
-Also, defualt context can be provided on contract initialization:
+Also, default context can be provided on contract initialization:
 
 ```ruby
 user = UserRepo.new.find(42)


### PR DESCRIPTION
Fixes a small typo in the rules section of the dry-validation documentation.