### PR TITLE
Depend on dry-schema 1.8.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -15,4 +15,4 @@ gemspec:
     - [dry-core, "~> 0.5", ">= 0.5"]
     - [dry-container, "~> 0.7", ">= 0.7.1"]
     - [dry-initializer, "~> 3.0"]
-    - [dry-schema, "~> 1.5", ">= 1.5.2"]
+    - [dry-schema, "~> 1.8", ">= 1.8.0"]


### PR DESCRIPTION
This ensures the dry-configurable 0.13.0 `setting` API is available (which we also use here)