### PR TITLE
Add hints extension to docs

### DIFF
--- a/docsite/source/extensions.html.md
+++ b/docsite/source/extensions.html.md
@@ -59,3 +59,15 @@ end
 AgeContract.new.(age: 17).errors.first.text
 # => 'must be greater than or equal to 18'
 ```
+
+### Hints
+
+The hints extension is implemented in [dry-schema](https://dry-rb.org/gems/dry-schema/main/extensions/hints/). This extension enables hints in Contracts.  
+
+To enable the extension:
+
+```ruby
+require 'dry/validation'
+
+Dry::Validation.load_extensions(:hints)
+```


### PR DESCRIPTION
The extension got moved to dry-schema but it is still needed in
dry-validation to enable hints for contracts.