### PR TITLE
Duplicated keys mishandling in rule evaluation

### DIFF
--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -140,8 +140,9 @@ module Dry
 
         path
           .to_a[0..-2]
-          .any? { |key|
-            curr_path = Schema::Path[path.keys[0..path.keys.index(key)]]
+          .each_with_index
+          .any? { |_key, index|
+            curr_path = Schema::Path[path.keys[0..index]]
 
             return false unless result.schema_error?(curr_path)
 


### PR DESCRIPTION
Given a `Contract` that has a duplicate key and some rule defined that passes through both of the keys:

```ruby
class DuplicatedKeyContract < Dry::Validation::Contract
  schema do
    required(:data).hash do
      required(:wrapper).hash do
        required(:data).hash.do
          required(:id).filled(:string)
        end
      end 
    end
  end

  register_macro(:min_size) do |macro:|
    min = macro.args[0]
    key.failure("must have at least #{min} characters") unless value.size >= min
  end

  rule(%i[data wrapper data id]).validate(min_size: 10)
end

DuplicateKeyContract.new.(data: { wrapper: { data: [] } } ) 
#=> TypeError: no implict conversion of Symbol to Integer
```

When the `rule`s where being evaluated we call `Contract#error?` in order to decide if we should skip testing the rule for that key. In the example above we would end up returning that no errors exist for the second `:data` key due to a small oversight.

`Contract#error?` uses `path.keys.index(key)` will return the first match for the argument (as per `find_index` semantics). In the example above the first `:data` key has no errors, but the second one has one which will never be picked up.

The fix was making a call to `each_with_index` and using the actual `index` instead of trying to figure it out from the key.

Fixes #676