### PR TITLE
Removing guard since the gemspec requires RUBY_VERSION >= 2.7

### DIFF
--- a/lib/dry/validation/result.rb
+++ b/lib/dry/validation/result.rb
@@ -197,20 +197,18 @@ module Dry
         super
       end
 
-      if RUBY_VERSION >= "2.7"
-        # Pattern matching
-        #
-        # @api private
-        def deconstruct_keys(keys)
-          values.deconstruct_keys(keys)
-        end
+      # Pattern matching
+      #
+      # @api private
+      def deconstruct_keys(keys)
+        values.deconstruct_keys(keys)
+      end
 
-        # Pattern matching
-        #
-        # @api private
-        def deconstruct
-          [values, context.each.to_h]
-        end
+      # Pattern matching
+      #
+      # @api private
+      def deconstruct
+        [values, context.each.to_h]
       end
 
       private


### PR DESCRIPTION
Here:

https://github.com/dry-rb/dry-validation/blob/88a3c56898227f3c817d0e3e3acbe3aa8c61ae9f/dry-validation.gemspec#L28-L30

So the guard is not longer needed.