### PR TITLE
Validate input type and return a descriptive error

### DIFF
--- a/lib/dry/validation/contract.rb
+++ b/lib/dry/validation/contract.rb
@@ -90,6 +90,8 @@ module Dry
       # @api public
       # rubocop: disable Metrics/AbcSize
       def call(input, context = EMPTY_HASH)
+        validate_input_type(input)
+
         context_map = Concurrent::Map.new.tap do |map|
           default_context.each { |key, value| map[key] = value }
           context.each { |key, value| map[key] = value }
@@ -160,6 +162,12 @@ module Dry
       # @api private
       def messages
         self.class.messages
+      end
+
+      def validate_input_type(input)
+        return if input.is_a?(Hash)
+
+        raise ArgumentError, "Input must be a Hash. #{input.class} was given."
       end
     end
   end

--- a/spec/integration/contract/call_spec.rb
+++ b/spec/integration/contract/call_spec.rb
@@ -135,6 +135,22 @@ RSpec.describe Dry::Validation::Contract, "#call" do
     expect(result.errors.to_h).to eql(address: {geolocation: {lon: ["invalid longitude"]}})
   end
 
+  context "when input argument is an integer" do
+    it "raises a descriptive error" do
+      result = -> { contract.(5) }
+
+      expect(&result).to raise_error(ArgumentError, "Input must be a Hash. Integer was given.")
+    end
+  end
+
+  context "when input argument is an array" do
+    it "raises a descriptive error" do
+      result = -> { contract.([{name: "Tomas"}]) }
+
+      expect(&result).to raise_error(ArgumentError, "Input must be a Hash. Array was given.")
+    end
+  end
+
   context "duplicate key names on nested structures" do
     subject(:contract) do
       Class.new(Dry::Validation::Contract) do


### PR DESCRIPTION
As described in issue https://github.com/dry-rb/dry-validation/issues/716, the error raised when wrong input is given to the `Contract#call` method is confusing. It is the `NoMethodError` instead of `ArgumentError`.

I'm adding here a validation to fix that and return a descriptive error message.

If only we had a type system... ;)