### PR TITLE
Remove ruby 2.7 from the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
         - '3.2'
         - '3.1'
         - '3.0'
-        - '2.7'
         include:
         - ruby: '3.2'
           coverage: 'true'
@@ -77,7 +76,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.0
     - name: Install dependencies
       run: gem install ossy --no-document
     - name: Trigger release workflow


### PR DESCRIPTION
Due to the change in `template-gem` in the end of 2022, the support for Ruby 2.7 was dropped - https://github.com/dry-rb/template-gem/commit/ebec158cbbd97e0cb3200acfdc299ef622b5cca0

I'm removing here the references to Ruby 2.7 in the CI config. It is responsible for some failures in CI jobs in last weeks.

I've left one reference in `.github/workflows/custom/ci.yml`, because I don't know what is this flow and if it's even used.