### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/dry-validation.gemspec
+++ b/dry-validation.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"]     = "https://github.com/dry-rb/dry-validation/blob/main/CHANGELOG.md"
   spec.metadata["source_code_uri"]   = "https://github.com/dry-rb/dry-validation"
   spec.metadata["bug_tracker_uri"]   = "https://github.com/dry-rb/dry-validation/issues"
+  spec.metadata["funding_uri"]       = "https://github.com/sponsors/hanami"
 
   spec.required_ruby_version = ">= 3.0"
 


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml, this PR adds `funding_uri` to the gemspec to help increase visibility using the `bundle fund` command in Bundler.

Happy to open similar PRs for all the dry-rb gems if this is accepted.